### PR TITLE
forgot to change to es6 modules

### DIFF
--- a/.github/workflows/run-pr-tag-gen.yml
+++ b/.github/workflows/run-pr-tag-gen.yml
@@ -69,8 +69,8 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
-            const script = require('./workflow-helpers/get-release-label.js')
-            await script({github, context, core})
+            const { default: run } = await import('${{ github.workspace }}/workflow-helpers/get-release-label.js')
+            await run({github, context, core})
       
       # Bump Semver based on previous tag
       - name: "Bump semantic version"
@@ -81,8 +81,8 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
-            const script = require('./workflow-helpers/bump-semver.js')
-            await script({github, context, core})
+            const { default: run } = await import('${{ github.workspace }}/workflow-helpers/bump-semver.js')
+            await run({github, context, core})
 
       # Push new tag to repo
       - name: Push tag

--- a/workflow-helpers/bump-semver.js
+++ b/workflow-helpers/bump-semver.js
@@ -3,7 +3,7 @@ import * as semver from 'semver';
 
 // @ts-check
 /** @param {import('@actions/github-script').AsyncFunctionArguments} AsyncFunctionArguments */
-export default async ({ github, core, context }) => {
+export default async function run({ github, core, context }) {
   core.debug("Running something at the moment");
   try {
     const currentVersion = process.env.INPUT_TAG;
@@ -15,7 +15,7 @@ export default async ({ github, core, context }) => {
     core.error(e);
     core.setFailed(e.message);
   }
-};
+}
 
 async function bumpSemver(
   currentVersion,

--- a/workflow-helpers/get-release-label.js
+++ b/workflow-helpers/get-release-label.js
@@ -1,7 +1,7 @@
 
 // @ts-check
 /** @param {import('@actions/github-script').AsyncFunctionArguments} AsyncFunctionArguments */
-export default async ({ github, core, context }) => {
+export default async function run({ github, core, context }) {
   core.debug("Running something at the moment");
   try {
     // Get labels for pull_request
@@ -30,4 +30,4 @@ export default async ({ github, core, context }) => {
     core.error(e);
     core.setFailed(e.message);
   }
-};
+}


### PR DESCRIPTION
This pull request updates how JavaScript helper scripts are imported and executed in the GitHub Actions workflow, and refactors the default exports in those helper scripts for better compatibility with dynamic imports. The main focus is on improving the workflow's maintainability and ensuring compatibility with ESM-style imports.

**Workflow and Script Refactoring:**

* Updated the GitHub Actions workflow (`.github/workflows/run-pr-tag-gen.yml`) to use dynamic ESM-style imports (`import ... from`) instead of CommonJS `require` when loading the `get-release-label.js` and `bump-semver.js` scripts. This change ensures compatibility with modern JavaScript module standards. [[1]](diffhunk://#diff-6545d8810fdefa46283051a1876142d0bc71aa632e09bf6690e9afae086e2a2fL72-R73) [[2]](diffhunk://#diff-6545d8810fdefa46283051a1876142d0bc71aa632e09bf6690e9afae086e2a2fL84-R85)

**Helper Script Improvements:**

* Refactored the default exports in both `workflow-helpers/get-release-label.js` and `workflow-helpers/bump-semver.js` to use named async functions (`async function run(...)`) instead of anonymous arrow functions. This makes the scripts easier to import dynamically and improves stack traces for debugging. [[1]](diffhunk://#diff-a576ad462316e5fa15aa8d2e6386fc2bb7eb5de35a5f4aca536743e66ae1e15cL4-R4) [[2]](diffhunk://#diff-a576ad462316e5fa15aa8d2e6386fc2bb7eb5de35a5f4aca536743e66ae1e15cL33-R33) [[3]](diffhunk://#diff-54d9f0af2a52b4089e8ff7d578c81a271248602bb525dda6b5fbb714c1afb6d3L6-R6) [[4]](diffhunk://#diff-54d9f0af2a52b4089e8ff7d578c81a271248602bb525dda6b5fbb714c1afb6d3L18-R18)