### PR TITLE
Update to new way of importing semver

### DIFF
--- a/.github/workflows/run-pr-tag-gen.yml
+++ b/.github/workflows/run-pr-tag-gen.yml
@@ -25,8 +25,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '20.x'
-      # Install dependencies
-      - run: npm install -g semver@7.6.3
 
       # Get Latest Tag for Repo
       - name: "Get latest tag"
@@ -64,6 +62,8 @@ jobs:
 
           echo "tag=${latest_tag}" >> $GITHUB_OUTPUT
 
+
+      # Set bump level based on pr labels
       - name: Set bump level
         id: set-bump-level
         uses: actions/github-script@v8
@@ -71,8 +71,9 @@ jobs:
           script: |
             const { default: run } = await import('${{ github.workspace }}/workflow-helpers/get-release-label.js')
             await run({github, context, core})
-      
+
       # Bump Semver based on previous tag
+      - run: npm install -g semver
       - name: "Bump semantic version"
         id: "bump-semver"
         env:
@@ -81,8 +82,9 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
+            const semver = require('semver');
             const { default: run } = await import('${{ github.workspace }}/workflow-helpers/bump-semver.js')
-            await run({github, context, core})
+            await run({github, context, core}, semver)
 
       # Push new tag to repo
       - name: Push tag

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,8 @@
   "packages": {
     "": {
       "devDependencies": {
-        "@actions/github-script": "github:actions/github-script"
+        "@actions/github-script": "github:actions/github-script",
+        "semver": "^7.7.2"
       }
     },
     "node_modules/@actions/core": {
@@ -384,6 +385,19 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/tunnel": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "devDependencies": {
-    "@actions/github-script": "github:actions/github-script"
+    "@actions/github-script": "github:actions/github-script",
+    "semver": "^7.7.2"
   }
 }

--- a/workflow-helpers/bump-semver.js
+++ b/workflow-helpers/bump-semver.js
@@ -1,23 +1,23 @@
 
-import * as semver from 'semver';
-
 // @ts-check
-/** @param {import('@actions/github-script').AsyncFunctionArguments} AsyncFunctionArguments */
-export default async function run({ github, core, context }) {
-  core.debug("Running something at the moment");
+/** @param {import('@actions/github-script').AsyncFunctionArguments} git */
+/** @param {import('semver')} semver */
+export default async function run(git, semver) {
+  git.core.debug("Running something at the moment");
   try {
     const currentVersion = process.env.INPUT_TAG;
     const bumpLevel = process.env.BUMP_LEVEL || 'patch';
 
-    const newVersion = await bumpSemver(currentVersion, bumpLevel);
-    core.setOutput('new_version', newVersion);
+    const newVersion = await bumpSemver(semver, currentVersion, bumpLevel);
+    git.core.setOutput('new_version', newVersion);
   } catch (e) {
-    core.error(e);
-    core.setFailed(e.message);
+    git.core.error(e);
+    git.core.setFailed(e.message);
   }
 }
 
 async function bumpSemver(
+  semver,
   currentVersion,
   bumpLevel
 ) {


### PR DESCRIPTION
This pull request updates how semantic versioning is handled in the workflow for generating PR tags. The main change is to ensure that the correct version of the `semver` package is installed and explicitly passed into the helper script, rather than relying on a bundled or pre-installed version. This improves reliability and maintainability of the version bumping process.

**Workflow and Dependency Management Improvements:**

* The workflow now installs the latest `semver` package (`7.7.2`) as a dev dependency in `package.json` and ensures it is installed in the workflow before running the version bump step. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R4) [[2]](diffhunk://#diff-6545d8810fdefa46283051a1876142d0bc71aa632e09bf6690e9afae086e2a2fR76)
* The global install of `semver` is moved to just before it is needed, and the previous install step at the beginning of the workflow is removed to avoid redundancy. [[1]](diffhunk://#diff-6545d8810fdefa46283051a1876142d0bc71aa632e09bf6690e9afae086e2a2fL28-L29) [[2]](diffhunk://#diff-6545d8810fdefa46283051a1876142d0bc71aa632e09bf6690e9afae086e2a2fR76)

**Script and Workflow Refactoring:**

* The `bump-semver.js` helper script is refactored to accept the `semver` module as an explicit argument instead of importing it directly, improving testability and compatibility with the GitHub Actions environment. [[1]](diffhunk://#diff-54d9f0af2a52b4089e8ff7d578c81a271248602bb525dda6b5fbb714c1afb6d3L2-R20) [[2]](diffhunk://#diff-6545d8810fdefa46283051a1876142d0bc71aa632e09bf6690e9afae086e2a2fR85-R87)
* The workflow step that calls the helper script is updated to require and pass the `semver` module explicitly.
* Minor workflow organization improvements, such as clarifying comments and grouping steps logically (e.g., setting bump level after fetching the latest tag).