### PR TITLE
Added documentation with scalar and open api under /docs (#50)

### DIFF
--- a/.sqlx/query-1ab34dcbb13e0b5c55984daaaf7ec52878fa222d0110a48ae2d740dd89b220a9.json
+++ b/.sqlx/query-1ab34dcbb13e0b5c55984daaaf7ec52878fa222d0110a48ae2d740dd89b220a9.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO user_homes (user_id, home_id)\n            VALUES ($1, $2)\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "1ab34dcbb13e0b5c55984daaaf7ec52878fa222d0110a48ae2d740dd89b220a9"
+}

--- a/.sqlx/query-1c910ed106f44c28296aa1c1e4a8098308a4170d5bda8b5dc29834a918d84c51.json
+++ b/.sqlx/query-1c910ed106f44c28296aa1c1e4a8098308a4170d5bda8b5dc29834a918d84c51.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n            INSERT INTO homes (name, address, token)\n            VALUES ($1, $2, $3)\n            RETURNING id, name, address, token\n            ",
+  "query": "\n            INSERT INTO homes (id, name, address, token)\n            VALUES ($1, $2, $3, $4)\n            RETURNING id, name, address, token\n            ",
   "describe": {
     "columns": [
       {
@@ -26,6 +26,7 @@
     ],
     "parameters": {
       "Left": [
+        "Uuid",
         "Varchar",
         "Varchar",
         "Varchar"
@@ -38,5 +39,5 @@
       false
     ]
   },
-  "hash": "f35130e9662dc66802da95159efe21b3cc5097f5ddddd6e327aecf499e712293"
+  "hash": "1c910ed106f44c28296aa1c1e4a8098308a4170d5bda8b5dc29834a918d84c51"
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,14 +51,15 @@ checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 name = "api"
 version = "0.1.0"
 dependencies = [
- "axum",
- "axum-extra",
+ "axum 0.8.6",
+ "axum-extra 0.10.3",
  "chrono",
  "lib-db",
  "lib-models",
  "lib-utils",
  "once_cell",
  "reqwest",
+ "scalar_api_reference",
  "serde",
  "serde_json",
  "sqlx",
@@ -66,6 +67,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber",
+ "utoipa",
  "uuid",
 ]
 
@@ -79,6 +81,17 @@ dependencies = [
  "blake2",
  "cpufeatures",
  "password-hash",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -128,11 +141,45 @@ dependencies = [
 
 [[package]]
 name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core 0.4.5",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit 0.7.3",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a18ed336352031311f4e0b4dd2ff392d4fbb370777c9d18d7fc9d7359f73871"
 dependencies = [
- "axum-core",
+ "axum-core 0.5.5",
  "axum-macros",
  "base64",
  "bytes",
@@ -144,7 +191,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "itoa",
- "matchit",
+ "matchit 0.8.4",
  "memchr",
  "mime",
  "multer",
@@ -159,6 +206,27 @@ dependencies = [
  "tokio",
  "tokio-tungstenite",
  "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -185,12 +253,35 @@ dependencies = [
 
 [[package]]
 name = "axum-extra"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c794b30c904f0a1c2fb7740f7df7f7972dfaa14ef6f57cb6178dc63e5dca2f04"
+dependencies = [
+ "axum 0.7.9",
+ "axum-core 0.4.5",
+ "bytes",
+ "fastrand",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "multer",
+ "pin-project-lite",
+ "serde",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-extra"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9963ff19f40c6102c76756ef0a46004c0d58957d87259fc9208ff8441c12ab96"
 dependencies = [
- "axum",
- "axum-core",
+ "axum 0.8.6",
+ "axum-core 0.5.5",
  "bytes",
  "futures-util",
  "headers",
@@ -1129,6 +1220,8 @@ checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1236,13 +1329,14 @@ name = "lib-models"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "axum",
+ "axum 0.8.6",
  "chrono",
  "serde",
  "serde_json",
  "sqlx",
  "thiserror",
  "tokio",
+ "utoipa",
  "uuid",
 ]
 
@@ -1251,8 +1345,8 @@ name = "lib-utils"
 version = "0.1.0"
 dependencies = [
  "argon2",
- "axum",
- "axum-extra",
+ "axum 0.8.6",
+ "axum-extra 0.10.3",
  "base64",
  "jsonwebtoken",
  "lib-models",
@@ -1340,6 +1434,12 @@ checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
 ]
+
+[[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "matchit"
@@ -1914,6 +2014,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-embed"
+version = "8.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "947d7f3fad52b283d261c4c99a084937e2fe492248cb9a68a8435a861b8798ca"
+dependencies = [
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "8.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fa2c8c9e8711e10f9c4fd2d64317ef13feaab820a4c51541f1a8c8e2e851ab2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils",
+ "syn",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "8.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60b161f275cb337fe0a44d924a5f4df0ed69c2c39519858f931ce61c779d3475"
+dependencies = [
+ "sha2",
+ "walkdir",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1983,6 +2117,28 @@ name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "scalar_api_reference"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b3efdac145ec337b9db75e6d1d8732980551c07490ef9db72947e2af592f051"
+dependencies = [
+ "axum 0.7.9",
+ "axum-extra 0.9.6",
+ "rust-embed",
+ "serde_json",
+ "tokio",
+]
 
 [[package]]
 name = "schannel"
@@ -2875,6 +3031,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
+name = "utoipa"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fcc29c80c21c31608227e0912b2d7fddba57ad76b606890627ba8ee7964e993"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_json",
+ "utoipa-gen",
+]
+
+[[package]]
+name = "utoipa-gen"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d79d08d92ab8af4c5e8a6da20c47ae3f61a0f1dabc1997cdf2d082b757ca08b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "uuid",
+]
+
+[[package]]
 name = "uuid"
 version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2903,6 +3083,16 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "want"
@@ -3051,6 +3241,15 @@ checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
 dependencies = [
  "libredox",
  "wasite",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,5 +29,6 @@ sqlx = { version = "^0.8", features = [
   "chrono",
   "tls-rustls",
 ] }
+utoipa = { version = "^5.4", features = ["uuid", "chrono"] }
 thiserror = "^2.0"
 anyhow = "^1"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       BACKEND_PORT: ${BACKEND_PORT}
       FRONTEND_PORT: ${FRONTEND_PORT}
       AUTH_SECRET: ${AUTH_SECRET}
+      LOG_LEVEL: debug
     depends_on:
       database:
         condition: service_healthy
@@ -63,9 +64,9 @@ services:
     # container_name: surrealdb
     # env_file:
     #   - .env
-    # entrypoint: 
-    #   - /surreal 
-    #   - start 
+    # entrypoint:
+    #   - /surreal
+    #   - start
     #   - --user
     #   - ${SURREALDB_USER}
     #   - --pass

--- a/src/lib/lib-models/Cargo.toml
+++ b/src/lib/lib-models/Cargo.toml
@@ -16,3 +16,4 @@ thiserror = { workspace = true }
 anyhow = { workspace = true }
 axum = { workspace = true }
 sqlx = { workspace = true }
+utoipa = { workspace = true }

--- a/src/lib/lib-models/src/domain/auth.rs
+++ b/src/lib/lib-models/src/domain/auth.rs
@@ -1,7 +1,8 @@
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
 // the response that we pass back to HTTP client once successfully authorised
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct AuthBody {
     access_token: String,

--- a/src/lib/lib-models/src/domain/home.rs
+++ b/src/lib/lib-models/src/domain/home.rs
@@ -1,7 +1,8 @@
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 use uuid::Uuid;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct DomainHome {
     pub id: Uuid,
@@ -10,7 +11,7 @@ pub struct DomainHome {
     pub write_token: String, // base64 encoded random token
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct DomainNewHome {
     pub name: String,

--- a/src/lib/lib-models/src/domain/power.rs
+++ b/src/lib/lib-models/src/domain/power.rs
@@ -1,7 +1,8 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct PowerMetrics {
     pub home_id: String, //uuid::Uuid,

--- a/src/lib/lib-models/src/domain/user.rs
+++ b/src/lib/lib-models/src/domain/user.rs
@@ -1,8 +1,9 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 use uuid::Uuid;
 
-#[derive(Clone, Deserialize, Serialize)]
+#[derive(Clone, Deserialize, Serialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct NewDomainUser {
     pub email: String,
@@ -11,7 +12,7 @@ pub struct NewDomainUser {
     pub last_name: String,
 }
 
-#[derive(Clone, Deserialize, Serialize)]
+#[derive(Clone, Deserialize, Serialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct DomainUser {
     pub id: Uuid,
@@ -24,7 +25,7 @@ pub struct DomainUser {
     pub updated_at: DateTime<Utc>,
 }
 
-#[derive(Clone, Deserialize, Serialize)]
+#[derive(Clone, Deserialize, Serialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct AuthUser {
     pub email: String,

--- a/src/lib/lib-models/src/error.rs
+++ b/src/lib/lib-models/src/error.rs
@@ -9,8 +9,9 @@ use sqlx::Error as SqlxError;
 // use surrealdb::Error as SurrealError;
 use thiserror::Error;
 use tokio::sync::mpsc::error::TrySendError;
+use utoipa::ToSchema;
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, ToSchema)]
 pub enum Error {
     #[error("Internal Server Error")]
     InternalServerError,

--- a/src/services/api/Cargo.toml
+++ b/src/services/api/Cargo.toml
@@ -20,10 +20,12 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 sqlx = { workspace = true }
 axum = { workspace = true }
+utoipa = { workspace = true }
 
 # Service specific dependencies
 axum-extra = { version = "^0.10", features = ["typed-header"] }
 once_cell = "^1.21"
 tower-http = { version = "^0.6", features = ["trace", "cors", "fs"] }
 reqwest = "0.12.4"
+scalar_api_reference = { version = "0.1.0", features = ["axum"] }
 # oauth2 = "4.4.2"

--- a/src/services/api/src/main.rs
+++ b/src/services/api/src/main.rs
@@ -7,7 +7,7 @@ mod routes;
 #[tokio::main]
 async fn main() -> Result<(), Error> {
     // Add logging
-    let filter = match std::env::var("RUST_LOG") {
+    let filter = match std::env::var("LOG_LEVEL") {
         Ok(level) => match level.as_str() {
             "trace" => Level::TRACE,
             "debug" => Level::DEBUG,

--- a/src/services/api/src/routes/auth.rs
+++ b/src/services/api/src/routes/auth.rs
@@ -8,6 +8,16 @@ use lib_utils::crypto;
 
 use super::AppState;
 
+#[utoipa::path(
+    post,
+    path = "/user/login",
+    tag = "auth",
+    request_body = AuthUser,
+    responses(
+        (status = 200, description = "User logged in successfully", body = serde_json::Value),
+        (status = 500, description = "Internal Server Error", body = serde_json::Value),
+    )
+)]
 pub async fn log_in(
     State(state): State<AppState>,
     Json(auth_user): Json<AuthUser>,
@@ -37,6 +47,17 @@ pub async fn log_in(
     }
 }
 
+#[utoipa::path(
+    post,
+    path = "/user/signup",
+    tag = "auth",
+    request_body = NewDomainUser,
+    responses(
+        (status = 201, description = "User signed up successfully", body = serde_json::Value),
+        (status = 409, description = "Conflict - User already exists", body = serde_json::Value),
+        (status = 500, description = "Internal Server Error", body = serde_json::Value),
+    )
+)]
 pub async fn sign_up(
     State(state): State<AppState>,
     Json(new_user): Json<NewDomainUser>,

--- a/src/services/api/src/routes/home.rs
+++ b/src/services/api/src/routes/home.rs
@@ -4,6 +4,18 @@ use lib_models::{domain::home::DomainNewHome, error::Error};
 
 use crate::routes::AppState;
 
+#[utoipa::path(
+    post,
+    path = "/home",
+    tag = "home",
+    request_body = DomainNewHome,
+    responses(
+        (status = 200, description = "Home saved", body = lib_models::domain::home::DomainHome),
+        (status = 401, description = "Unauthorized", body = String),
+        (status = 409, description = "Conflict", body = String),
+        (status = 500, description = "Internal Server Error", body = String),
+    )
+)]
 pub async fn post_home(
     claims: lib_utils::crypto::Claims,
     State(state): State<AppState>,

--- a/src/services/api/src/routes/mod.rs
+++ b/src/services/api/src/routes/mod.rs
@@ -1,10 +1,28 @@
 // use axum::middleware::from_fn_with_state;
-use axum::routing::{get, post};
+use axum::{
+    response::{Html, IntoResponse},
+    routing::{get, post},
+};
+use scalar_api_reference::scalar_html;
+use serde_json::json;
 use tower_http::trace::TraceLayer;
+use utoipa::OpenApi;
 
 pub mod auth;
 pub mod home;
 pub mod power;
+
+#[derive(OpenApi)]
+#[openapi(paths(
+    // Auth
+    auth::log_in,
+    auth::sign_up,
+    // Home
+    home::post_home,
+    // Power
+    // power::post::post_power_metric,
+))]
+struct ApiDoc;
 
 #[derive(Clone)]
 pub struct AppState {
@@ -21,7 +39,9 @@ pub fn create_router(db: lib_db::Db) -> axum::Router {
     //     .layer(from_fn_with_state(app_state.clone(), auth::jwt_auth))
     //     .with_state(app_state.clone());
 
-    let unauthorized_routes: axum::Router = axum::Router::new()
+    let routes: axum::Router = axum::Router::new()
+        .route("/openapi.json", get(openapi_json))
+        .route("/docs", get(swagger_ui))
         .route("/home", post(home::post_home))
         .route("/power", post(power::post::post_power_metric))
         // Health check endpoint
@@ -33,6 +53,23 @@ pub fn create_router(db: lib_db::Db) -> axum::Router {
     axum::Router::new()
         // Health check endpoint
         // .merge(authorized_routes)
-        .merge(unauthorized_routes)
+        .merge(routes)
         .layer(TraceLayer::new_for_http())
+}
+
+pub async fn openapi_json() -> impl IntoResponse {
+    ApiDoc::openapi().to_pretty_json().unwrap()
+}
+
+pub async fn swagger_ui() -> impl IntoResponse {
+    // Generate HTML with configuration using CDN
+    let configuration = json!({
+        "url": "/openapi.json",
+        "theme": "purple"
+    });
+
+    // Using CDN fallback
+    let html = scalar_html(&configuration, None);
+
+    Html(html)
 }


### PR DESCRIPTION
This pull request introduces OpenAPI documentation generation and Swagger UI for the API, improves type safety and documentation with `utoipa` derives, and makes some small changes to logging and database queries. The main themes are API documentation integration and improvements to the data model.

**API Documentation and Swagger UI Integration**
* Added `utoipa` and `scalar_api_reference` dependencies, and implemented OpenAPI schema generation for authentication, home, and power endpoints in `src/services/api/src/routes/mod.rs`. This includes a `/openapi.json` route for the OpenAPI spec and a `/docs` route for the Swagger UI, making the API self-documenting and easier to explore. [[1]](diffhunk://#diff-02e532423739b87bfd4d7f246ffa90e603ebabf0537e0f6fc92b2de982f5487dL2-R26) [[2]](diffhunk://#diff-02e532423739b87bfd4d7f246ffa90e603ebabf0537e0f6fc92b2de982f5487dL24-R44) [[3]](diffhunk://#diff-02e532423739b87bfd4d7f246ffa90e603ebabf0537e0f6fc92b2de982f5487dL36-R75) [[4]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R32) [[5]](diffhunk://#diff-70afc92bd9bb687498352599fb7ec3bebc5220f1c4bd698bbf3f7e246dc21783R19) [[6]](diffhunk://#diff-d4d0dd6ac9f050599b7c149ecf978332b4d6ed13b00094c2b7d7c65646afcd32R23-R30)
* Annotated the `log_in`, `sign_up`, and `post_home` endpoint functions with `utoipa::path` macros to describe request/response schemas and status codes. [[1]](diffhunk://#diff-2cc8b675c57814bd370bb48983fe7bfdede309143b02924483f8ffeb22fd7ff3R11-R20) [[2]](diffhunk://#diff-2cc8b675c57814bd370bb48983fe7bfdede309143b02924483f8ffeb22fd7ff3R50-R60) [[3]](diffhunk://#diff-c2244dff7012519ee23f8af0d2658529fa423bbcfd89c77e36037b855bca7cf6R7-R18)

**Type Safety and Model Documentation**
* Added `utoipa::ToSchema` derives to all relevant domain models and error types in `lib-models` (`auth.rs`, `home.rs`, `power.rs`, `user.rs`, `error.rs`) to enable automatic schema generation for API documentation. [[1]](diffhunk://#diff-6ba637ae89f3c2fa3475980710b7f66f2f4b4a2ab6722b188302f60f11e49d96R2-R5) [[2]](diffhunk://#diff-b8b73389116ff08abfdb7f9a32a80462ece8c895ba1cc314e4c1c0b17e64121dR2-R5) [[3]](diffhunk://#diff-b8b73389116ff08abfdb7f9a32a80462ece8c895ba1cc314e4c1c0b17e64121dL13-R14) [[4]](diffhunk://#diff-6a6c9ac561d8622a30a77dedd79602acf59ef1c35f8925cc51456308f4bcadefR3-R5) [[5]](diffhunk://#diff-51b7a1ac94741708176e91f61cf3adbf21890362d54ac74a68ea9f7b50c17719R3-R6) [[6]](diffhunk://#diff-51b7a1ac94741708176e91f61cf3adbf21890362d54ac74a68ea9f7b50c17719L14-R15) [[7]](diffhunk://#diff-51b7a1ac94741708176e91f61cf3adbf21890362d54ac74a68ea9f7b50c17719L27-R28) [[8]](diffhunk://#diff-6c734424b73ff29af260f2f3862e337551010c1c66188f9259b2b36772eb46a0R12-R14)

**Database Query Updates**
* Updated SQLX query for inserting a new home to require an explicit `id` parameter, improving data integrity. [[1]](diffhunk://#diff-258f01e48cede9f33a36ac058dffee68b6f04995690c98ade875c17d7b4e7e2aL3-R3) [[2]](diffhunk://#diff-258f01e48cede9f33a36ac058dffee68b6f04995690c98ade875c17d7b4e7e2aR29) [[3]](diffhunk://#diff-258f01e48cede9f33a36ac058dffee68b6f04995690c98ade875c17d7b4e7e2aL41-R42)
* Added a new SQLX query file for inserting a user-home relationship.

**Logging Improvements**
* Changed the environment variable for log level in the API from `RUST_LOG` to `LOG_LEVEL`, and set the default log level to debug in Docker Compose for better observability during development. [[1]](diffhunk://#diff-ae896d35ce08b66f91e5d2b7f931679988781ccfe534349fb00f491e0c9eeb79L10-R10) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R16)