### PR TITLE
changed to execute to avoid listening to returning results

### DIFF
--- a/src/lib/lib-db/src/power/mod.rs
+++ b/src/lib/lib-db/src/power/mod.rs
@@ -61,7 +61,7 @@ impl PowerMetric {
             new_powermetric.cost_since_midnight,
             new_powermetric.currency,
         )
-        .fetch_one(&db.pool)
+        .execute(&db.pool)
         .await?;
 
         Ok(true)


### PR DESCRIPTION
This pull request makes a minor change to how a database operation is performed in the `PowerMetric` implementation. Instead of fetching a single result, the code now executes the query without expecting a returned row, which is more appropriate for operations that do not require data retrieval.