### PR TITLE
(#66) Tried implementing dockerentry point to manage env vars

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 .cargo/
 .env
 target/
+**/node_modules/
 

--- a/.env.example
+++ b/.env.example
@@ -17,9 +17,11 @@ DB_SCHEMA=public
 # Frontend settings
 FRONTEND_PORT=3000
 
-# Webapp settings (Vite)
-# URL of the backend API (used by the webapp)
+# Webapp settings
+# VITE_API_URL is used by Vite during local development (npm run dev)
 VITE_API_URL=http://localhost:3001
+# API_URL is injected at container startup by docker-entrypoint.sh (runtime)
+API_URL=http://localhost:3001
 
 # Auth (legacy NextAuth fields, kept for reference)
 NEXTAUTH_URL=http://localhost:3000

--- a/Dockerfile.webapp
+++ b/Dockerfile.webapp
@@ -21,10 +21,14 @@ FROM nginx:alpine AS prod
 # Copy built assets
 COPY --from=build /app/dist /usr/share/nginx/html
 
+# Copy entrypoint script that injects runtime env vars before starting nginx
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
 # Metadata
 LABEL maintainer="Martin Ellegard"
 LABEL repository="https://github.com/cg-homelab/smarter-home"
 
 EXPOSE 80
 
-CMD ["nginx", "-g", "daemon off;"]
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
     ports:
       - ${FRONTEND_PORT}:80
     environment:
-      - VITE_API_URL:http://backend:${BACKEND_PORT}
+      - API_URL=http://backend:${BACKEND_PORT}
     depends_on:
       - backend
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
     ports:
       - ${FRONTEND_PORT}:80
     environment:
-      - API_URL=http://backend:${BACKEND_PORT}
+      - API_URL=http://localhost:${BACKEND_PORT}
     depends_on:
       - backend
     networks:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Write runtime environment variables into a JS file that the webapp loads
+# before the main bundle. This allows the container to be configured at
+# startup without rebuilding the static assets.
+
+cat <<EOF > /usr/share/nginx/html/config.js
+window.__ENV__ = {
+  apiBaseUrl: "${API_URL:-http://localhost:3001}"
+};
+EOF
+
+exec nginx -g "daemon off;"

--- a/src/services/webapp/index.html
+++ b/src/services/webapp/index.html
@@ -8,6 +8,8 @@
   </head>
   <body>
     <div id="root"></div>
+    <!-- Runtime environment config injected by docker-entrypoint.sh -->
+    <script src="/config.js"></script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/src/services/webapp/src/lib/config.ts
+++ b/src/services/webapp/src/lib/config.ts
@@ -1,5 +1,14 @@
+declare global {
+  interface Window {
+    __ENV__?: { apiBaseUrl: string };
+  }
+}
+
 const CONFIG = {
-  apiBaseUrl: import.meta.env.VITE_API_URL || "http://localhost:3001",
+  apiBaseUrl:
+    window.__ENV__?.apiBaseUrl ??
+    import.meta.env.VITE_API_URL ??
+    "http://localhost:3001",
   tokenKey: "smarter_home_token",
   timeout: 5000,
   endpoints: {


### PR DESCRIPTION
Will give a remix framework convertion in the future

This pull request introduces runtime environment variable injection for the webapp, allowing the frontend container to be configured at startup without rebuilding static assets. It adds a startup script to generate a `config.js` file with environment variables, updates configuration handling in the frontend code, and adjusts Docker and Compose settings accordingly.

**Runtime environment variable injection:**

* Added `docker-entrypoint.sh` script to generate `/usr/share/nginx/html/config.js` at container startup, exposing `API_URL` as `window.__ENV__` for the frontend to consume.
* Updated `Dockerfile.webapp` to copy and use the entrypoint script, replacing the default `nginx` command.

**Frontend configuration changes:**

* Modified `src/lib/config.ts` to read `apiBaseUrl` from `window.__ENV__` (populated by `config.js`), falling back to `VITE_API_URL` or a default value.
* Updated `index.html` to load the generated `config.js` before the main bundle, ensuring runtime config is available.

**Docker Compose and environment variable updates:**

* Changed `docker-compose.yml` to pass `API_URL` (instead of `VITE_API_URL`) to the frontend container for runtime configuration.
* Clarified `.env.example` to distinguish between build-time (`VITE_API_URL`) and runtime (`API_URL`) environment variables for the frontend.

**Other improvements:**

* Updated `.dockerignore` to exclude all `node_modules` directories from build context.