### PR TITLE
Fixed bad dbg logging from back when crypto library was in the making

### DIFF
--- a/src/lib/lib-utils/src/crypto.rs
+++ b/src/lib/lib-utils/src/crypto.rs
@@ -98,7 +98,6 @@ where
     async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
         // let decoding_key = DecodingKey::from_secret(KEYS.as_bytes());
         // Extract the token from the authorization header
-        dbg!(parts.clone());
         let TypedHeader(Authorization(bearer)) = parts
             .extract::<TypedHeader<Authorization<Bearer>>>()
             .await
@@ -159,7 +158,6 @@ pub fn generate_jwt(sub: String, role: Role, id: Option<Uuid>, indefenant: bool)
     // let encoding_key = EncodingKey::from_secret(KEYS.as_bytes());
 
     let claims = Claims { sub, role, id, exp };
-    dbg!(claims.clone());
 
     encode(&Header::new(Algorithm::HS256), &claims, &KEYS.encoding)
         .unwrap_or("failed_to_generate_token".to_string())


### PR DESCRIPTION
This pull request makes a couple of minor clean-up changes to the `crypto.rs` utility by removing leftover debugging statements. These changes help keep the codebase clean and production-ready. No functional logic was altered.