### PR TITLE
Feature/69 web powermetrics and integration

### DIFF
--- a/.sqlx/query-1409fef83781f1994a293fe432e22a0555c8c6b1a2d29a97f2bae41875ce7e11.json
+++ b/.sqlx/query-1409fef83781f1994a293fe432e22a0555c8c6b1a2d29a97f2bae41875ce7e11.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE user_homes SET is_favorite = $1 WHERE home_id = $2 AND user_id = $3",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Bool",
+        "Uuid",
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "1409fef83781f1994a293fe432e22a0555c8c6b1a2d29a97f2bae41875ce7e11"
+}

--- a/.sqlx/query-1b0eea1a8a17c49d17b7d29c92ad4893e2f2360e990c907866fb9c8d8f99ba2e.json
+++ b/.sqlx/query-1b0eea1a8a17c49d17b7d29c92ad4893e2f2360e990c907866fb9c8d8f99ba2e.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n            SELECT h.id, h.name, h.address, h.token, h.tibber_token\n            FROM homes h\n            JOIN user_homes uh ON h.id = uh.home_id\n            WHERE uh.user_id = $1\n            ",
+  "query": "\n            SELECT h.id, h.name, h.address, h.token, h.tibber_token, uh.is_favorite\n            FROM homes h\n            JOIN user_homes uh ON h.id = uh.home_id\n            WHERE uh.user_id = $1\n            ",
   "describe": {
     "columns": [
       {
@@ -27,6 +27,11 @@
         "ordinal": 4,
         "name": "tibber_token",
         "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "is_favorite",
+        "type_info": "Bool"
       }
     ],
     "parameters": {
@@ -39,8 +44,9 @@
       false,
       false,
       false,
-      true
+      true,
+      false
     ]
   },
-  "hash": "727e5a4dd5614721c59ef50a54685b0fe54914cf229f438143c878f0fa775b43"
+  "hash": "1b0eea1a8a17c49d17b7d29c92ad4893e2f2360e990c907866fb9c8d8f99ba2e"
 }

--- a/.sqlx/query-8169488c2c2dc04ca1b87cedcd1823bd1007dad163fb3c21b6f00eb1d05d5b6a.json
+++ b/.sqlx/query-8169488c2c2dc04ca1b87cedcd1823bd1007dad163fb3c21b6f00eb1d05d5b6a.json
@@ -1,0 +1,46 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT id, name, address, token, tibber_token\n            FROM homes\n            WHERE id = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "address",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "token",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "tibber_token",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      true
+    ]
+  },
+  "hash": "8169488c2c2dc04ca1b87cedcd1823bd1007dad163fb3c21b6f00eb1d05d5b6a"
+}

--- a/.sqlx/query-8d2b0bd0436ed73ab6fb600bbc8d9b15484f08d9a2d61ef54bb6824db8bc6b37.json
+++ b/.sqlx/query-8d2b0bd0436ed73ab6fb600bbc8d9b15484f08d9a2d61ef54bb6824db8bc6b37.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT is_favorite FROM user_homes WHERE home_id = $1 AND user_id = $2",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "is_favorite",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "8d2b0bd0436ed73ab6fb600bbc8d9b15484f08d9a2d61ef54bb6824db8bc6b37"
+}

--- a/Makefile
+++ b/Makefile
@@ -45,13 +45,21 @@ stop-docker:
 start-database:
 	@docker compose up -d database
 
-# Run api without docker
-dev-api:
+# API
+api-dev:
 	@cargo run --bin api
+api-lint:
+	@cargo clippy --bin api
+api-format:
+	@cargo fmt
 
-# Run webapp without docker
-dev-web:
+# Webapp
+web-dev:
 	@cd src/services/webapp && bun run dev
+web-lint:
+	@cd src/services/webapp && bun run lint
+web-format:
+	@cd src/services/webapp && bun run format
 
 ## Database
 # Check status of database

--- a/migrations/0007_favorite-home.down.sql
+++ b/migrations/0007_favorite-home.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE user_homes DROP COLUMN is_favorite;

--- a/migrations/0007_favorite-home.up.sql
+++ b/migrations/0007_favorite-home.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE user_homes ADD COLUMN is_favorite BOOLEAN NOT NULL DEFAULT false;

--- a/src/lib/lib-db/src/home/mod.rs
+++ b/src/lib/lib-db/src/home/mod.rs
@@ -115,6 +115,7 @@ impl Home {
             name: home.name,
             address: home.address,
             write_token: home.token,
+            is_favorite: false,
         })
     }
 
@@ -125,11 +126,10 @@ impl Home {
     /// # Returns
     /// * `Result<Vec<DomainHome>, Error>` - List of homes or error
     pub async fn get_homes(db: &Db, user_id: Uuid) -> Result<Vec<DomainHome>, Error> {
-        // Get all homes for a user
-        let homes = sqlx::query_as!(
-            Home,
+        // Get all homes for a user, including per-user favorite status
+        let homes = sqlx::query!(
             r#"
-            SELECT h.id, h.name, h.address, h.token, h.tibber_token
+            SELECT h.id, h.name, h.address, h.token, h.tibber_token, uh.is_favorite
             FROM homes h
             JOIN user_homes uh ON h.id = uh.home_id
             WHERE uh.user_id = $1
@@ -140,11 +140,12 @@ impl Home {
         .await?;
         let domain_homes = homes
             .into_iter()
-            .map(|home| DomainHome {
-                id: home.id,
-                name: home.name,
-                address: home.address,
-                write_token: home.token,
+            .map(|r| DomainHome {
+                id: r.id,
+                name: r.name,
+                address: r.address,
+                write_token: r.token,
+                is_favorite: r.is_favorite,
             })
             .collect();
         Ok(domain_homes)
@@ -154,12 +155,14 @@ impl Home {
     /// # Arguments
     /// * `db` - Database connection
     /// * `home_id` - Home ID to update
+    /// * `user_id` - User ID (used to retrieve per-user favorite status)
     /// * `update` - Updated home data
     /// # Returns
     /// * `Result<DomainHome, Error>` - Updated home or error
     pub async fn update_home(
         db: &Db,
         home_id: Uuid,
+        user_id: Uuid,
         update: &DomainUpdateHome,
     ) -> Result<DomainHome, Error> {
         let home = sqlx::query_as!(
@@ -177,11 +180,69 @@ impl Home {
         .fetch_one(&db.pool)
         .await?;
 
+        let is_favorite = sqlx::query!(
+            "SELECT is_favorite FROM user_homes WHERE home_id = $1 AND user_id = $2",
+            home_id,
+            user_id,
+        )
+        .fetch_one(&db.pool)
+        .await?
+        .is_favorite;
+
         Ok(DomainHome {
             id: home.id,
             name: home.name,
             address: home.address,
             write_token: home.token,
+            is_favorite,
+        })
+    }
+
+    /// Set the favorite status of a home for a specific user
+    /// # Arguments
+    /// * `db` - Database connection
+    /// * `home_id` - Home ID
+    /// * `user_id` - User ID
+    /// * `is_favorite` - New favorite status
+    /// # Returns
+    /// * `Result<DomainHome, Error>` - Updated home or error
+    pub async fn set_favorite_home(
+        db: &Db,
+        home_id: Uuid,
+        user_id: Uuid,
+        is_favorite: bool,
+    ) -> Result<DomainHome, Error> {
+        let result = sqlx::query!(
+            "UPDATE user_homes SET is_favorite = $1 WHERE home_id = $2 AND user_id = $3",
+            is_favorite,
+            home_id,
+            user_id,
+        )
+        .execute(&db.pool)
+        .await?;
+
+        if result.rows_affected() == 0 {
+            return Err(Error::EntityNotFound);
+        }
+
+        let home = sqlx::query_as!(
+            Home,
+            r#"
+            SELECT id, name, address, token, tibber_token
+            FROM homes
+            WHERE id = $1
+            "#,
+            home_id,
+        )
+        .fetch_one(&db.pool)
+        .await?;
+
+        Ok(DomainHome {
+            id: home.id,
+            name: home.name,
+            address: home.address,
+            write_token: home.token,
+            is_favorite,
         })
     }
 

--- a/src/lib/lib-db/src/home/mod.rs
+++ b/src/lib/lib-db/src/home/mod.rs
@@ -253,12 +253,9 @@ impl Home {
     /// # Returns
     /// * `Result<(), Error>` - Ok if deleted, error otherwise
     pub async fn delete_home(db: &Db, home_id: Uuid) -> Result<(), Error> {
-        let result = sqlx::query!(
-            "DELETE FROM homes WHERE id = $1",
-            home_id,
-        )
-        .execute(&db.pool)
-        .await?;
+        let result = sqlx::query!("DELETE FROM homes WHERE id = $1", home_id,)
+            .execute(&db.pool)
+            .await?;
 
         if result.rows_affected() == 0 {
             return Err(Error::EntityNotFound);

--- a/src/lib/lib-models/src/domain/home.rs
+++ b/src/lib/lib-models/src/domain/home.rs
@@ -8,6 +8,7 @@ use uuid::Uuid;
 /// * `name` - Home name
 /// * `address` - Home address
 /// * `write_token` - access token for writing data to the home
+/// * `is_favorite` - whether the home is marked as favorite by the requesting user
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct DomainHome {
@@ -15,6 +16,7 @@ pub struct DomainHome {
     pub name: String,
     pub address: String,
     pub write_token: String,
+    pub is_favorite: bool,
 }
 
 /// DomainNewHome struct representing a new home to be created in the domain layer
@@ -37,4 +39,13 @@ pub struct DomainNewHome {
 pub struct DomainUpdateHome {
     pub name: String,
     pub address: String,
+}
+
+/// DomainSetFavoriteHome struct for toggling the favorite status of a home
+/// # Fields
+/// * `is_favorite` - whether to mark the home as favorite
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct DomainSetFavoriteHome {
+    pub is_favorite: bool,
 }

--- a/src/services/api/src/routes/home/mod.rs
+++ b/src/services/api/src/routes/home/mod.rs
@@ -5,7 +5,7 @@ use axum::{
 };
 use lib_db::home;
 use lib_models::{
-    domain::home::{DomainNewHome, DomainUpdateHome},
+    domain::home::{DomainNewHome, DomainSetFavoriteHome, DomainUpdateHome},
     error::Error,
 };
 use lib_utils::crypto::Claims;
@@ -165,7 +165,7 @@ pub async fn put_home(
         }
     }
 
-    match home::Home::update_home(&state.db, home_id, &input).await {
+    match home::Home::update_home(&state.db, home_id, user_id, &input).await {
         Ok(updated) => {
             tracing::debug!("Home {} updated", home_id);
             Json(updated).into_response()
@@ -233,6 +233,70 @@ pub async fn delete_home(
         }
         Err(error) => {
             tracing::warn!("Delete home failed: {:0}", &error);
+            error.into_response()
+        }
+    }
+}
+
+/// Sets the favorite status of a home for the authenticated user.
+#[utoipa::path(
+    patch,
+    path = "/home/{id}/favorite",
+    tag = "home",
+    params(
+        ("id" = Uuid, Path, description = "Home ID")
+    ),
+    request_body = DomainSetFavoriteHome,
+    responses(
+        (status = 200, description = "Favorite status updated", body = lib_models::domain::home::DomainHome),
+        (status = 401, description = "Unauthorized", body = String),
+        (status = 403, description = "Forbidden", body = String),
+        (status = 404, description = "Not found", body = String),
+        (status = 500, description = "Internal Server Error", body = String),
+    )
+)]
+pub async fn patch_home_favorite(
+    claims: Claims,
+    State(state): State<AppState>,
+    Path(home_id): Path<Uuid>,
+    Json(input): Json<DomainSetFavoriteHome>,
+) -> impl IntoResponse {
+    tracing::debug!(
+        "User {} is attempting to set favorite={} on home {}",
+        claims.sub,
+        input.is_favorite,
+        home_id
+    );
+
+    let user_id = match claims.id {
+        Some(id) => id,
+        None => {
+            let error = Error::Unauthorized;
+            tracing::debug!("Set favorite failed: {:0}", &error);
+            return error.into_response();
+        }
+    };
+
+    match home::Home::check_user_on_home(&state.db, home_id, user_id).await {
+        Ok(true) => {}
+        Ok(false) => {
+            let error = Error::Forbidden;
+            tracing::warn!("Set favorite forbidden for user {}", user_id);
+            return error.into_response();
+        }
+        Err(error) => {
+            tracing::warn!("Ownership check failed: {:0}", &error);
+            return error.into_response();
+        }
+    }
+
+    match home::Home::set_favorite_home(&state.db, home_id, user_id, input.is_favorite).await {
+        Ok(updated) => {
+            tracing::debug!("Home {} favorite set to {}", home_id, input.is_favorite);
+            Json(updated).into_response()
+        }
+        Err(error) => {
+            tracing::warn!("Set favorite failed: {:0}", &error);
             error.into_response()
         }
     }

--- a/src/services/api/src/routes/mod.rs
+++ b/src/services/api/src/routes/mod.rs
@@ -1,7 +1,7 @@
 // use axum::middleware::from_fn_with_state;
 use axum::{
     response::{Html, IntoResponse},
-    routing::{delete, get, post, put},
+    routing::{delete, get, patch, post, put},
 };
 use scalar_api_reference::scalar_html;
 use serde_json::json;
@@ -32,6 +32,7 @@ pub mod user;
         home::get_homes,
         home::put_home,
         home::delete_home,
+        home::patch_home_favorite,
         // Power
         power::post::post_power_metric,
         power::get::get_metrics_for_period,
@@ -70,6 +71,7 @@ pub fn create_router(db: lib_db::Db) -> axum::Router {
         .route("/home", get(home::get_homes))
         .route("/home/{id}", put(home::put_home))
         .route("/home/{id}", delete(home::delete_home))
+        .route("/home/{id}/favorite", patch(home::patch_home_favorite))
         .with_state(app_state.clone());
 
     let cors = CorsLayer::new()

--- a/src/services/webapp/app/(app)/dashboard/actions.ts
+++ b/src/services/webapp/app/(app)/dashboard/actions.ts
@@ -1,0 +1,100 @@
+'use server'
+
+import { apiFetch } from '@/lib/api'
+import type { Home } from '@/app/(app)/homes/actions'
+
+export interface PowerMetrics {
+    homeId: string
+    ts: string
+    price: number
+    power: number
+    solarPower: number
+    lastMeterConsumption: number
+    lastMeterProduction: number
+    lastSolarTotal: number
+    consumptionSinceMidnight: number
+    productionSinceMidnight: number
+    solarSinceMidnight: number
+    costSinceMidnight: number
+    currency: string
+}
+
+const USE_MOCK = process.env.DASHBOARD_MOCK === 'true'
+
+/** Generates 30 minutes of synthetic power readings (one per minute). */
+function buildMockMetrics(homeId: string): PowerMetrics[] {
+    const now = Date.now()
+    // Simulate a house that starts consuming ~1500 W, solar kicks in around
+    // the midpoint and briefly pushes net power negative.
+    const curve = [
+        1800, 1650, 1500, 1420, 1300, 1100, 900, 700, 500, 300, 100, -50,
+        -200, -350, -500, -620, -700, -580, -400, -200, 0, 150, 350, 500,
+        700, 900, 1100, 1300, 1450, 1600,
+    ]
+    return curve.map((power, i) => {
+        const ts = new Date(now - (29 - i) * 60 * 1000).toISOString()
+        return {
+            homeId,
+            ts,
+            price: 0.12,
+            power,
+            solarPower: power < 0 ? Math.abs(power) + 400 : 0,
+            lastMeterConsumption: 12345.6 + i * 0.02,
+            lastMeterProduction: 4321.0 + (power < 0 ? i * 0.01 : 0),
+            lastSolarTotal: 8765.4 + i * 0.015,
+            consumptionSinceMidnight: 4.2 + i * 0.025,
+            productionSinceMidnight: 1.1 + (power < 0 ? i * 0.01 : 0),
+            solarSinceMidnight: 2.3 + i * 0.015,
+            costSinceMidnight: 0.5 + i * 0.003,
+            currency: 'NOK',
+        }
+    })
+}
+
+export async function getMockDashboardData(): Promise<{
+    home: Home | null
+    metrics: PowerMetrics[]
+}> {
+    const home: Home = {
+        id: 'mock-home-id',
+        name: 'Mock Home',
+        address: '1 Example Street',
+        writeToken: 'mock-token',
+        isFavorite: true,
+    }
+    return { home, metrics: buildMockMetrics(home.id) }
+}
+
+export async function getDashboardData(): Promise<{
+    home: Home | null
+    metrics: PowerMetrics[]
+}> {
+    if (USE_MOCK) return getMockDashboardData()
+
+    try {
+        const homes = await apiFetch<Home[]>('/home', { tags: ['homes'] })
+        const home = homes.find((h) => h.isFavorite) ?? homes[0] ?? null
+
+        if (!home) {
+            return { home: null, metrics: [] }
+        }
+
+        const endDate = new Date()
+        const startDate = new Date(endDate.getTime() - 30 * 60 * 1000)
+
+        const params = new URLSearchParams({
+            home_id: home.id,
+            start_date: startDate.toISOString(),
+            end_date: endDate.toISOString(),
+        })
+
+        const metrics = await apiFetch<PowerMetrics[]>(
+            `/power/metrics?${params}`,
+            { cache: 'no-store' },
+        )
+
+        return { home, metrics }
+    } catch {
+        return { home: null, metrics: [] }
+    }
+}

--- a/src/services/webapp/app/(app)/dashboard/actions.ts
+++ b/src/services/webapp/app/(app)/dashboard/actions.ts
@@ -27,9 +27,9 @@ function buildMockMetrics(homeId: string): PowerMetrics[] {
     // Simulate a house that starts consuming ~1500 W, solar kicks in around
     // the midpoint and briefly pushes net power negative.
     const curve = [
-        1800, 1650, 1500, 1420, 1300, 1100, 900, 700, 500, 300, 100, -50,
-        -200, -350, -500, -620, -700, -580, -400, -200, 0, 150, 350, 500,
-        700, 900, 1100, 1300, 1450, 1600,
+        1800, 1650, 1500, 1420, 1300, 1100, 900, 700, 500, 300, 100, -50, -200,
+        -350, -500, -620, -700, -580, -400, -200, 0, 150, 350, 500, 700, 900,
+        1100, 1300, 1450, 1600,
     ]
     return curve.map((power, i) => {
         const ts = new Date(now - (29 - i) * 60 * 1000).toISOString()

--- a/src/services/webapp/app/(app)/dashboard/page.tsx
+++ b/src/services/webapp/app/(app)/dashboard/page.tsx
@@ -14,10 +14,7 @@ export default async function DashboardPage() {
                     Energy analytics dashboard
                 </p>
             </div>
-            <PowerLineChart
-                metrics={metrics}
-                homeName={home?.name ?? null}
-            />
+            <PowerLineChart metrics={metrics} homeName={home?.name ?? null} />
         </div>
     )
 }

--- a/src/services/webapp/app/(app)/dashboard/page.tsx
+++ b/src/services/webapp/app/(app)/dashboard/page.tsx
@@ -1,6 +1,9 @@
-import { PowerConsumptionChart } from '@/components/analytics/power-consumption'
+import { getDashboardData } from './actions'
+import { PowerLineChart } from '@/components/analytics/power-line-chart'
 
-export default function DashboardPage() {
+export default async function DashboardPage() {
+    const { home, metrics } = await getDashboardData()
+
     return (
         <div className="flex flex-col gap-6 p-4 sm:p-6 lg:p-8">
             <div className="flex flex-col sm:flex-row sm:items-center gap-1">
@@ -11,9 +14,10 @@ export default function DashboardPage() {
                     Energy analytics dashboard
                 </p>
             </div>
-            <div>
-                <PowerConsumptionChart />
-            </div>
+            <PowerLineChart
+                metrics={metrics}
+                homeName={home?.name ?? null}
+            />
         </div>
     )
 }

--- a/src/services/webapp/app/(app)/homes/actions.ts
+++ b/src/services/webapp/app/(app)/homes/actions.ts
@@ -8,6 +8,7 @@ export interface Home {
     name: string
     address: string
     writeToken: string
+    isFavorite: boolean
 }
 
 export interface NewHome {
@@ -48,4 +49,14 @@ export async function updateHomeAction(
 export async function deleteHomeAction(id: string): Promise<void> {
     await apiFetch<void>(`/home/${id}`, { method: 'DELETE' })
     //   revalidateTag("homes");
+}
+
+export async function setFavoriteHomeAction(
+    id: string,
+    isFavorite: boolean,
+): Promise<Home> {
+    return await apiFetch<Home>(`/home/${id}/favorite`, {
+        method: 'PATCH',
+        body: JSON.stringify({ isFavorite }),
+    })
 }

--- a/src/services/webapp/components/analytics/power-line-chart.tsx
+++ b/src/services/webapp/components/analytics/power-line-chart.tsx
@@ -43,7 +43,9 @@ export function PowerLineChart({ metrics, homeName }: PowerLineChartProps) {
                 <CardContent className="flex flex-col items-center justify-center gap-3 py-16 text-center text-muted-foreground">
                     <Zap className="h-10 w-10 opacity-40" />
                     <div>
-                        <p className="text-sm font-medium">No home configured</p>
+                        <p className="text-sm font-medium">
+                            No home configured
+                        </p>
                         <p className="text-xs">
                             Add a home to start seeing power metrics.
                         </p>

--- a/src/services/webapp/components/analytics/power-line-chart.tsx
+++ b/src/services/webapp/components/analytics/power-line-chart.tsx
@@ -1,0 +1,235 @@
+'use client'
+
+import * as React from 'react'
+import {
+    AreaChart,
+    Area,
+    XAxis,
+    YAxis,
+    CartesianGrid,
+    ReferenceLine,
+} from 'recharts'
+import { AlertCircle, Zap } from 'lucide-react'
+import {
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+} from '@/components/ui/card'
+import {
+    type ChartConfig,
+    ChartContainer,
+    ChartTooltip,
+    ChartTooltipContent,
+} from '@/components/ui/chart'
+import type { PowerMetrics } from '@/app/(app)/dashboard/actions'
+
+interface PowerLineChartProps {
+    metrics: PowerMetrics[]
+    homeName: string | null
+}
+
+const chartConfig = {
+    power: {
+        label: 'Power (W)',
+    },
+} satisfies ChartConfig
+
+export function PowerLineChart({ metrics, homeName }: PowerLineChartProps) {
+    if (!homeName) {
+        return (
+            <Card>
+                <CardContent className="flex flex-col items-center justify-center gap-3 py-16 text-center text-muted-foreground">
+                    <Zap className="h-10 w-10 opacity-40" />
+                    <div>
+                        <p className="text-sm font-medium">No home configured</p>
+                        <p className="text-xs">
+                            Add a home to start seeing power metrics.
+                        </p>
+                    </div>
+                </CardContent>
+            </Card>
+        )
+    }
+
+    const chartData = metrics.map((m) => ({
+        time: m.ts,
+        power: Math.round(m.power * 10) / 10,
+    }))
+
+    if (chartData.length === 0) {
+        return (
+            <Card>
+                <CardHeader>
+                    <CardTitle>Live Power — {homeName}</CardTitle>
+                    <CardDescription>Last 30 minutes</CardDescription>
+                </CardHeader>
+                <CardContent className="flex flex-col items-center justify-center gap-3 py-16 text-center text-muted-foreground">
+                    <AlertCircle className="h-10 w-10 opacity-40" />
+                    <div>
+                        <p className="text-sm font-medium">No data yet</p>
+                        <p className="text-xs">
+                            No power readings in the last 30 minutes.
+                        </p>
+                    </div>
+                </CardContent>
+            </Card>
+        )
+    }
+
+    const maxPower = Math.max(...chartData.map((d) => d.power))
+    const minPower = Math.min(...chartData.map((d) => d.power))
+    const range = maxPower - minPower
+
+    // Fraction from the top of the chart where y=0 sits.
+    // SVG y-axis: 0 = top (max value), 1 = bottom (min value).
+    // Clamped to [0, 1] so all-positive or all-negative datasets
+    // still produce a clean single-colour gradient.
+    const zeroOffset =
+        range > 0 ? Math.min(Math.max(maxPower / range, 0), 1) : 0.5
+    const zeroPercent = `${(zeroOffset * 100).toFixed(1)}%`
+
+    const hasNegative = minPower < 0
+    const hasPositive = maxPower > 0
+
+    const description =
+        hasNegative && !hasPositive
+            ? 'Producing power — surplus to grid'
+            : hasPositive && !hasNegative
+              ? 'Consuming power from grid'
+              : 'Green = net production · Red = net consumption'
+
+    return (
+        <Card className="pt-0">
+            <CardHeader className="flex items-center gap-2 space-y-0 border-b py-5 sm:flex-row">
+                <div className="grid flex-1 gap-1">
+                    <CardTitle>Live Power — {homeName}</CardTitle>
+                    <CardDescription>{description}</CardDescription>
+                </div>
+            </CardHeader>
+            <CardContent className="px-2 pt-4 sm:px-6 sm:pt-6">
+                <ChartContainer
+                    config={chartConfig}
+                    className="aspect-auto h-[250px] w-full"
+                >
+                    <AreaChart data={chartData}>
+                        <defs>
+                            {/* Stroke gradient: red above zero, green below */}
+                            <linearGradient
+                                id="powerStroke"
+                                x1="0"
+                                y1="0"
+                                x2="0"
+                                y2="1"
+                            >
+                                <stop
+                                    offset={zeroPercent}
+                                    stopColor="var(--destructive)"
+                                />
+                                <stop
+                                    offset={zeroPercent}
+                                    stopColor="var(--chart-2)"
+                                />
+                            </linearGradient>
+
+                            {/* Fill gradient: faint red above zero, faint green below */}
+                            <linearGradient
+                                id="powerFill"
+                                x1="0"
+                                y1="0"
+                                x2="0"
+                                y2="1"
+                            >
+                                <stop
+                                    offset="0%"
+                                    stopColor="var(--destructive)"
+                                    stopOpacity={0.2}
+                                />
+                                <stop
+                                    offset={zeroPercent}
+                                    stopColor="var(--destructive)"
+                                    stopOpacity={0.02}
+                                />
+                                <stop
+                                    offset={zeroPercent}
+                                    stopColor="var(--chart-2)"
+                                    stopOpacity={0.02}
+                                />
+                                <stop
+                                    offset="100%"
+                                    stopColor="var(--chart-2)"
+                                    stopOpacity={0.2}
+                                />
+                            </linearGradient>
+                        </defs>
+
+                        <CartesianGrid vertical={false} />
+
+                        <XAxis
+                            dataKey="time"
+                            tickLine={false}
+                            axisLine={false}
+                            tickMargin={8}
+                            minTickGap={48}
+                            tickFormatter={(value: string) =>
+                                new Date(value).toLocaleTimeString('en-GB', {
+                                    hour: '2-digit',
+                                    minute: '2-digit',
+                                })
+                            }
+                        />
+
+                        <YAxis
+                            tickLine={false}
+                            axisLine={false}
+                            tickMargin={8}
+                            width={58}
+                            tickFormatter={(v: number) => `${v}W`}
+                        />
+
+                        {/* Zero baseline */}
+                        <ReferenceLine
+                            y={0}
+                            stroke="var(--border)"
+                            strokeDasharray="4 4"
+                        />
+
+                        <ChartTooltip
+                            cursor={{ strokeDasharray: '3 3' }}
+                            content={
+                                <ChartTooltipContent
+                                    labelFormatter={(value: string) =>
+                                        new Date(value).toLocaleTimeString(
+                                            'en-GB',
+                                            {
+                                                hour: '2-digit',
+                                                minute: '2-digit',
+                                                second: '2-digit',
+                                            },
+                                        )
+                                    }
+                                    formatter={(value) => [
+                                        `${value} W`,
+                                        'Power',
+                                    ]}
+                                />
+                            }
+                        />
+
+                        <Area
+                            dataKey="power"
+                            type="monotone"
+                            stroke="url(#powerStroke)"
+                            fill="url(#powerFill)"
+                            strokeWidth={2}
+                            dot={false}
+                            activeDot={{ r: 4 }}
+                            baseValue={0}
+                        />
+                    </AreaChart>
+                </ChartContainer>
+            </CardContent>
+        </Card>
+    )
+}

--- a/src/services/webapp/components/homes/homes-client.tsx
+++ b/src/services/webapp/components/homes/homes-client.tsx
@@ -14,6 +14,7 @@ import {
     X,
     Trash2,
     Star,
+    Fingerprint,
 } from 'lucide-react'
 import {
     Home as HomeModel,
@@ -75,6 +76,9 @@ export function HomesClient({ initialHomes, initialError }: HomesClientProps) {
     >(new Set())
 
     const [revealedTokens, setRevealedTokens] = React.useState<Set<string>>(
+        new Set(),
+    )
+    const [revealedIds, setRevealedIds] = React.useState<Set<string>>(
         new Set(),
     )
 
@@ -161,6 +165,18 @@ export function HomesClient({ initialHomes, initialError }: HomesClientProps) {
                 return next
             })
         }
+    }
+
+    function toggleId(id: string) {
+        setRevealedIds((prev) => {
+            const next = new Set(prev)
+            if (next.has(id)) {
+                next.delete(id)
+            } else {
+                next.add(id)
+            }
+            return next
+        })
     }
 
     function toggleToken(id: string) {
@@ -334,6 +350,7 @@ export function HomesClient({ initialHomes, initialError }: HomesClientProps) {
                     {homes.map((home) => {
                         const isEditing = editingId === home.id
                         const isRevealed = revealedTokens.has(home.id)
+                        const isIdRevealed = revealedIds.has(home.id)
 
                         return (
                             <Card key={home.id}>
@@ -496,6 +513,26 @@ export function HomesClient({ initialHomes, initialError }: HomesClientProps) {
                                             <div className="flex items-start gap-2 text-sm text-muted-foreground">
                                                 <MapPin className="mt-0.5 h-4 w-4 shrink-0" />
                                                 <span>{home.address}</span>
+                                            </div>
+                                            <div className="flex items-center gap-2 text-sm">
+                                                <Fingerprint className="h-4 w-4 shrink-0 text-muted-foreground" />
+                                                <code className="flex-1 truncate rounded bg-muted px-1.5 py-0.5 text-xs font-mono">
+                                                    {isIdRevealed
+                                                        ? home.id
+                                                        : '••••••••••••••••••••'}
+                                                </code>
+                                                <Button
+                                                    variant="ghost"
+                                                    size="sm"
+                                                    className="h-6 px-2 text-xs"
+                                                    onClick={() =>
+                                                        toggleId(home.id)
+                                                    }
+                                                >
+                                                    {isIdRevealed
+                                                        ? 'Hide'
+                                                        : 'Show'}
+                                                </Button>
                                             </div>
                                             <div className="flex items-center gap-2 text-sm">
                                                 <Key className="h-4 w-4 shrink-0 text-muted-foreground" />

--- a/src/services/webapp/components/homes/homes-client.tsx
+++ b/src/services/webapp/components/homes/homes-client.tsx
@@ -78,9 +78,7 @@ export function HomesClient({ initialHomes, initialError }: HomesClientProps) {
     const [revealedTokens, setRevealedTokens] = React.useState<Set<string>>(
         new Set(),
     )
-    const [revealedIds, setRevealedIds] = React.useState<Set<string>>(
-        new Set(),
-    )
+    const [revealedIds, setRevealedIds] = React.useState<Set<string>>(new Set())
 
     function handleFieldChange(e: React.ChangeEvent<HTMLInputElement>) {
         const { name, value } = e.target

--- a/src/services/webapp/components/homes/homes-client.tsx
+++ b/src/services/webapp/components/homes/homes-client.tsx
@@ -13,12 +13,14 @@ import {
     Check,
     X,
     Trash2,
+    Star,
 } from 'lucide-react'
 import {
     Home as HomeModel,
     createHomeAction,
     updateHomeAction,
     deleteHomeAction,
+    setFavoriteHomeAction,
 } from '@/app/(app)/homes/actions'
 import {
     Card,
@@ -66,6 +68,11 @@ export function HomesClient({ initialHomes, initialError }: HomesClientProps) {
         null,
     )
     const [deleteSubmitting, setDeleteSubmitting] = React.useState(false)
+
+    // Favorite state
+    const [favoriteSubmitting, setFavoriteSubmitting] = React.useState<
+        Set<string>
+    >(new Set())
 
     const [revealedTokens, setRevealedTokens] = React.useState<Set<string>>(
         new Set(),
@@ -131,6 +138,28 @@ export function HomesClient({ initialHomes, initialError }: HomesClientProps) {
             setEditError(apiErr.message ?? 'Failed to update home')
         } finally {
             setEditSubmitting(false)
+        }
+    }
+
+    async function handleToggleFavorite(home: HomeModel) {
+        setFavoriteSubmitting((prev) => new Set(prev).add(home.id))
+        try {
+            const updated = await setFavoriteHomeAction(
+                home.id,
+                !home.isFavorite,
+            )
+            setHomes((prev) =>
+                prev.map((h) => (h.id === home.id ? updated : h)),
+            )
+        } catch (err) {
+            const apiErr = err as { message?: string }
+            setError(apiErr.message ?? 'Failed to update favorite')
+        } finally {
+            setFavoriteSubmitting((prev) => {
+                const next = new Set(prev)
+                next.delete(home.id)
+                return next
+            })
         }
     }
 
@@ -409,6 +438,33 @@ export function HomesClient({ initialHomes, initialError }: HomesClientProps) {
                                                     {home.name}
                                                 </span>
                                                 <div className="flex items-center gap-1">
+                                                    <Button
+                                                        variant="ghost"
+                                                        size="sm"
+                                                        className={`h-7 w-7 p-0 ${home.isFavorite ? 'text-yellow-400 hover:text-yellow-500' : 'text-muted-foreground hover:text-yellow-400'}`}
+                                                        onClick={() =>
+                                                            handleToggleFavorite(
+                                                                home,
+                                                            )
+                                                        }
+                                                        disabled={favoriteSubmitting.has(
+                                                            home.id,
+                                                        )}
+                                                        aria-label={
+                                                            home.isFavorite
+                                                                ? 'Unmark as favorite'
+                                                                : 'Mark as favorite'
+                                                        }
+                                                    >
+                                                        <Star
+                                                            className="h-3.5 w-3.5"
+                                                            fill={
+                                                                home.isFavorite
+                                                                    ? 'currentColor'
+                                                                    : 'none'
+                                                            }
+                                                        />
+                                                    </Button>
                                                     <Button
                                                         variant="ghost"
                                                         size="sm"


### PR DESCRIPTION
This pull request introduces a new "favorite home" feature, allowing users to mark one or more homes as favorites. The changes span the database schema, backend API, and web application to support storing, updating, and retrieving per-user favorite status for homes.

**Backend and Database Enhancements:**

*Favorite Home Data Model:*
- Added a new `is_favorite` boolean column to the `user_homes` table to track each user's favorite homes. Includes migration scripts for adding and removing the column. [[1]](diffhunk://#diff-cde003bc94e351f5d8eb5f32e00cd578dedc5deacdaa914ba450f6d48d0d2436R1) [[2]](diffhunk://#diff-7ee65c70f3f90ad017a1e6c622776c3ecf0f5b702d7aa3d03143884668ad18a1R1)
- Updated SQL queries and data models to include the `is_favorite` field when fetching and updating homes. [[1]](diffhunk://#diff-7c394cd7f3f8b773d3dc8d7e8d06d04e9954bf84d52a6c5b33af81534094de51R1-R52) [[2]](diffhunk://#diff-ebc174d2618882739eba8e479c26fc80a37dd95adb96645223c6fbec751ef854R1-R23) [[3]](diffhunk://#diff-e3e0662b29db45d81bab0ac7ac19e8418c6e94dc86ca85c1382e204bf695f827R1-R16) [[4]](diffhunk://#diff-c6ba6a5f5d96b66161b27ad781d9a3968aa65e355a90df41ff5757af36a1748fL3-R3) [[5]](diffhunk://#diff-c6ba6a5f5d96b66161b27ad781d9a3968aa65e355a90df41ff5757af36a1748fL45-R45) [[6]](diffhunk://#diff-ef826596916bd7e553741845d5f1e2cf55c322e4fc7edd4f8e70b8750397117eR118) [[7]](diffhunk://#diff-ef826596916bd7e553741845d5f1e2cf55c322e4fc7edd4f8e70b8750397117eL128-R132) [[8]](diffhunk://#diff-ef826596916bd7e553741845d5f1e2cf55c322e4fc7edd4f8e70b8750397117eL143-R148) [[9]](diffhunk://#diff-b8b73389116ff08abfdb7f9a32a80462ece8c895ba1cc314e4c1c0b17e64121dR11-R19)

*API Changes:*
- Added a new PATCH endpoint `/home/{id}/favorite` to set or unset the favorite status for a home per user. This includes request/response models and OpenAPI documentation. [[1]](diffhunk://#diff-438f8df528cef26c7e55ffd83201cc42c0bcf110cc458e77c96bbab3951a854aR240-R303) [[2]](diffhunk://#diff-02e532423739b87bfd4d7f246ffa90e603ebabf0537e0f6fc92b2de982f5487dL4-R4) [[3]](diffhunk://#diff-02e532423739b87bfd4d7f246ffa90e603ebabf0537e0f6fc92b2de982f5487dR35) [[4]](diffhunk://#diff-02e532423739b87bfd4d7f246ffa90e603ebabf0537e0f6fc92b2de982f5487dR74) [[5]](diffhunk://#diff-b8b73389116ff08abfdb7f9a32a80462ece8c895ba1cc314e4c1c0b17e64121dR43-R51)
- Modified the update and get endpoints to include the favorite status in responses, ensuring the client always knows which homes are favorites for the current user. [[1]](diffhunk://#diff-ef826596916bd7e553741845d5f1e2cf55c322e4fc7edd4f8e70b8750397117eR158-R165) [[2]](diffhunk://#diff-ef826596916bd7e553741845d5f1e2cf55c322e4fc7edd4f8e70b8750397117eR183-R245) [[3]](diffhunk://#diff-438f8df528cef26c7e55ffd83201cc42c0bcf110cc458e77c96bbab3951a854aL168-R168)

**Web Application Updates:**

*Favorite Home Support:*
- Updated the `Home` type and home-related actions to include and support the `isFavorite` property. Added `setFavoriteHomeAction` to call the new backend endpoint. [[1]](diffhunk://#diff-aab71743c6633b6a03e237a09a294f11e9d6335c525f42834ff8c452e738c25eR11) [[2]](diffhunk://#diff-aab71743c6633b6a03e237a09a294f11e9d6335c525f42834ff8c452e738c25eR53-R62)
- Enhanced the dashboard logic to select the favorite home (if any) as the default for analytics display, falling back to the first home otherwise.
- Refactored the dashboard page to use the new data fetching logic, ensuring it displays analytics for the user's favorite home. [[1]](diffhunk://#diff-0a50af783223104b7af2510ebda1d422010937ef77da20f7e0b8b8c6d539e1c8L1-L3) [[2]](diffhunk://#diff-0a50af783223104b7af2510ebda1d422010937ef77da20f7e0b8b8c6d539e1c8L14-R20)

These changes together enable users to mark and retrieve their favorite homes, and ensure the dashboard and other features can leverage this preference to improve the user experience.