### PR TITLE
(#69) Fixed build error from type check

### DIFF
--- a/src/services/webapp/components/analytics/power-line-chart.tsx
+++ b/src/services/webapp/components/analytics/power-line-chart.tsx
@@ -201,15 +201,14 @@ export function PowerLineChart({ metrics, homeName }: PowerLineChartProps) {
                             cursor={{ strokeDasharray: '3 3' }}
                             content={
                                 <ChartTooltipContent
-                                    labelFormatter={(value: string) =>
-                                        new Date(value).toLocaleTimeString(
-                                            'en-GB',
-                                            {
-                                                hour: '2-digit',
-                                                minute: '2-digit',
-                                                second: '2-digit',
-                                            },
-                                        )
+                                    labelFormatter={(value) =>
+                                        new Date(
+                                            value as string,
+                                        ).toLocaleTimeString('en-GB', {
+                                            hour: '2-digit',
+                                            minute: '2-digit',
+                                            second: '2-digit',
+                                        })
                                     }
                                     formatter={(value) => [
                                         `${value} W`,


### PR DESCRIPTION
This pull request makes a small update to the `PowerLineChart` component to improve type safety and code clarity when formatting tooltip labels.

- Improved the `labelFormatter` function in `PowerLineChart` by explicitly casting the `value` parameter to a string before passing it to `Date`, ensuring correct type handling in the tooltip. (`src/services/webapp/components/analytics/power-line-chart.tsx`)