### PR TITLE
Feat/auth refresh tokens

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,3 +24,5 @@ API_URL=http://localhost:3001
 # Auth settings
 # Used by backend JWT signing/verification
 AUTH_SECRET=
+AUTH_ACCESS_TTL_SECS=900
+AUTH_REFRESH_TTL_SECS=2592000

--- a/.sqlx/query-13e17a29040d8765c2e4a06752b6f4801923cc87bd3603686497f46807404142.json
+++ b/.sqlx/query-13e17a29040d8765c2e4a06752b6f4801923cc87bd3603686497f46807404142.json
@@ -6,27 +6,57 @@
       {
         "ordinal": 0,
         "name": "id",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "homes",
+            "name": "id"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "name",
-        "type_info": "Varchar"
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "homes",
+            "name": "name"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "address",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "homes",
+            "name": "address"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "token",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "homes",
+            "name": "token"
+          }
+        }
       },
       {
         "ordinal": 4,
         "name": "tibber_token",
-        "type_info": "Varchar"
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "homes",
+            "name": "tibber_token"
+          }
+        }
       }
     ],
     "parameters": {

--- a/.sqlx/query-1b0eea1a8a17c49d17b7d29c92ad4893e2f2360e990c907866fb9c8d8f99ba2e.json
+++ b/.sqlx/query-1b0eea1a8a17c49d17b7d29c92ad4893e2f2360e990c907866fb9c8d8f99ba2e.json
@@ -6,32 +6,68 @@
       {
         "ordinal": 0,
         "name": "id",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "homes",
+            "name": "id"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "name",
-        "type_info": "Varchar"
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "homes",
+            "name": "name"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "address",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "homes",
+            "name": "address"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "token",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "homes",
+            "name": "token"
+          }
+        }
       },
       {
         "ordinal": 4,
         "name": "tibber_token",
-        "type_info": "Varchar"
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "homes",
+            "name": "tibber_token"
+          }
+        }
       },
       {
         "ordinal": 5,
         "name": "is_favorite",
-        "type_info": "Bool"
+        "type_info": "Bool",
+        "origin": {
+          "Table": {
+            "table": "user_homes",
+            "name": "is_favorite"
+          }
+        }
       }
     ],
     "parameters": {

--- a/.sqlx/query-2b62afb9f8925c40a5b9869733b11def0f9966941beab4a63de4f6ba5717ae8b.json
+++ b/.sqlx/query-2b62afb9f8925c40a5b9869733b11def0f9966941beab4a63de4f6ba5717ae8b.json
@@ -6,67 +6,145 @@
       {
         "ordinal": 0,
         "name": "home_id",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "power_metrics",
+            "name": "home_id"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "ts",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "power_metrics",
+            "name": "ts"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "price",
-        "type_info": "Float8"
+        "type_info": "Float8",
+        "origin": {
+          "Table": {
+            "table": "power_metrics",
+            "name": "price"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "power",
-        "type_info": "Float8"
+        "type_info": "Float8",
+        "origin": {
+          "Table": {
+            "table": "power_metrics",
+            "name": "power"
+          }
+        }
       },
       {
         "ordinal": 4,
         "name": "solar_power",
-        "type_info": "Float8"
+        "type_info": "Float8",
+        "origin": {
+          "Table": {
+            "table": "power_metrics",
+            "name": "solar_power"
+          }
+        }
       },
       {
         "ordinal": 5,
         "name": "last_meter_consumption",
-        "type_info": "Float8"
+        "type_info": "Float8",
+        "origin": {
+          "Table": {
+            "table": "power_metrics",
+            "name": "last_meter_consumption"
+          }
+        }
       },
       {
         "ordinal": 6,
         "name": "last_meter_production",
-        "type_info": "Float8"
+        "type_info": "Float8",
+        "origin": {
+          "Table": {
+            "table": "power_metrics",
+            "name": "last_meter_production"
+          }
+        }
       },
       {
         "ordinal": 7,
         "name": "last_solar_total",
-        "type_info": "Float8"
+        "type_info": "Float8",
+        "origin": {
+          "Table": {
+            "table": "power_metrics",
+            "name": "last_solar_total"
+          }
+        }
       },
       {
         "ordinal": 8,
         "name": "consumption_since_midnight",
-        "type_info": "Float8"
+        "type_info": "Float8",
+        "origin": {
+          "Table": {
+            "table": "power_metrics",
+            "name": "consumption_since_midnight"
+          }
+        }
       },
       {
         "ordinal": 9,
         "name": "production_since_midnight",
-        "type_info": "Float8"
+        "type_info": "Float8",
+        "origin": {
+          "Table": {
+            "table": "power_metrics",
+            "name": "production_since_midnight"
+          }
+        }
       },
       {
         "ordinal": 10,
         "name": "solar_since_midnight",
-        "type_info": "Float8"
+        "type_info": "Float8",
+        "origin": {
+          "Table": {
+            "table": "power_metrics",
+            "name": "solar_since_midnight"
+          }
+        }
       },
       {
         "ordinal": 11,
         "name": "cost_since_midnight",
-        "type_info": "Float8"
+        "type_info": "Float8",
+        "origin": {
+          "Table": {
+            "table": "power_metrics",
+            "name": "cost_since_midnight"
+          }
+        }
       },
       {
         "ordinal": 12,
         "name": "currency",
-        "type_info": "Varchar"
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "power_metrics",
+            "name": "currency"
+          }
+        }
       }
     ],
     "parameters": {

--- a/.sqlx/query-2ba14355d8e76e89da712812c99e405868d7bc42f0ea68bba13869908016136e.json
+++ b/.sqlx/query-2ba14355d8e76e89da712812c99e405868d7bc42f0ea68bba13869908016136e.json
@@ -6,42 +6,90 @@
       {
         "ordinal": 0,
         "name": "id",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "id"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "first_name",
-        "type_info": "Varchar"
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "first_name"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "last_name",
-        "type_info": "Varchar"
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "last_name"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "email",
-        "type_info": "Varchar"
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "email"
+          }
+        }
       },
       {
         "ordinal": 4,
         "name": "password_hash",
-        "type_info": "Varchar"
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "password_hash"
+          }
+        }
       },
       {
         "ordinal": 5,
         "name": "role",
-        "type_info": "Varchar"
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "role"
+          }
+        }
       },
       {
         "ordinal": 6,
         "name": "created_at",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "created_at"
+          }
+        }
       },
       {
         "ordinal": 7,
         "name": "updated_at",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "updated_at"
+          }
+        }
       }
     ],
     "parameters": {

--- a/.sqlx/query-3bced667f1f0980655d872270602b31f5eafb05c7daed2342ca11b86facbdc5a.json
+++ b/.sqlx/query-3bced667f1f0980655d872270602b31f5eafb05c7daed2342ca11b86facbdc5a.json
@@ -6,12 +6,24 @@
       {
         "ordinal": 0,
         "name": "user_id",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "user_salts",
+            "name": "user_id"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "salt",
-        "type_info": "Varchar"
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "user_salts",
+            "name": "salt"
+          }
+        }
       }
     ],
     "parameters": {

--- a/.sqlx/query-3db61a3cbb5ecb25d92d6f2e3f0e9669ffb189911be24fe0f9121dec70b5f9dc.json
+++ b/.sqlx/query-3db61a3cbb5ecb25d92d6f2e3f0e9669ffb189911be24fe0f9121dec70b5f9dc.json
@@ -6,7 +6,13 @@
       {
         "ordinal": 0,
         "name": "id",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "homes",
+            "name": "id"
+          }
+        }
       }
     ],
     "parameters": {

--- a/.sqlx/query-4560c237741ce9d4166aecd669770b3360a3ac71e649b293efb88d92c3254068.json
+++ b/.sqlx/query-4560c237741ce9d4166aecd669770b3360a3ac71e649b293efb88d92c3254068.json
@@ -6,7 +6,13 @@
       {
         "ordinal": 0,
         "name": "id",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "id"
+          }
+        }
       }
     ],
     "parameters": {

--- a/.sqlx/query-8169488c2c2dc04ca1b87cedcd1823bd1007dad163fb3c21b6f00eb1d05d5b6a.json
+++ b/.sqlx/query-8169488c2c2dc04ca1b87cedcd1823bd1007dad163fb3c21b6f00eb1d05d5b6a.json
@@ -6,27 +6,57 @@
       {
         "ordinal": 0,
         "name": "id",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "homes",
+            "name": "id"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "name",
-        "type_info": "Varchar"
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "homes",
+            "name": "name"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "address",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "homes",
+            "name": "address"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "token",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "homes",
+            "name": "token"
+          }
+        }
       },
       {
         "ordinal": 4,
         "name": "tibber_token",
-        "type_info": "Varchar"
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "homes",
+            "name": "tibber_token"
+          }
+        }
       }
     ],
     "parameters": {

--- a/.sqlx/query-843923b9a0257cf80f1dff554e7dc8fdfc05f489328e8376513124dfb42996e3.json
+++ b/.sqlx/query-843923b9a0257cf80f1dff554e7dc8fdfc05f489328e8376513124dfb42996e3.json
@@ -6,42 +6,90 @@
       {
         "ordinal": 0,
         "name": "id",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "id"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "first_name",
-        "type_info": "Varchar"
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "first_name"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "last_name",
-        "type_info": "Varchar"
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "last_name"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "email",
-        "type_info": "Varchar"
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "email"
+          }
+        }
       },
       {
         "ordinal": 4,
         "name": "password_hash",
-        "type_info": "Varchar"
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "password_hash"
+          }
+        }
       },
       {
         "ordinal": 5,
         "name": "role",
-        "type_info": "Varchar"
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "role"
+          }
+        }
       },
       {
         "ordinal": 6,
         "name": "created_at",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "created_at"
+          }
+        }
       },
       {
         "ordinal": 7,
         "name": "updated_at",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "updated_at"
+          }
+        }
       }
     ],
     "parameters": {

--- a/.sqlx/query-8a68ec7836df40c862000e4b0dad7f3d87285d8e471e7b04f229e1f43af03cdc.json
+++ b/.sqlx/query-8a68ec7836df40c862000e4b0dad7f3d87285d8e471e7b04f229e1f43af03cdc.json
@@ -6,27 +6,57 @@
       {
         "ordinal": 0,
         "name": "id",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "homes",
+            "name": "id"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "name",
-        "type_info": "Varchar"
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "homes",
+            "name": "name"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "address",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "homes",
+            "name": "address"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "token",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "homes",
+            "name": "token"
+          }
+        }
       },
       {
         "ordinal": 4,
         "name": "tibber_token",
-        "type_info": "Varchar"
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "homes",
+            "name": "tibber_token"
+          }
+        }
       }
     ],
     "parameters": {

--- a/.sqlx/query-8d2b0bd0436ed73ab6fb600bbc8d9b15484f08d9a2d61ef54bb6824db8bc6b37.json
+++ b/.sqlx/query-8d2b0bd0436ed73ab6fb600bbc8d9b15484f08d9a2d61ef54bb6824db8bc6b37.json
@@ -6,7 +6,13 @@
       {
         "ordinal": 0,
         "name": "is_favorite",
-        "type_info": "Bool"
+        "type_info": "Bool",
+        "origin": {
+          "Table": {
+            "table": "user_homes",
+            "name": "is_favorite"
+          }
+        }
       }
     ],
     "parameters": {

--- a/.sqlx/query-945b9f32c23cb990a200fc8bbe699ef5db6d8f36a286ad736d1e671c1d6fd5b7.json
+++ b/.sqlx/query-945b9f32c23cb990a200fc8bbe699ef5db6d8f36a286ad736d1e671c1d6fd5b7.json
@@ -6,7 +6,13 @@
       {
         "ordinal": 0,
         "name": "user_id",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "user_homes",
+            "name": "user_id"
+          }
+        }
       }
     ],
     "parameters": {

--- a/.sqlx/query-f3f58600e971f1be6cbe206bba24f77769f54c6230e28f5b3dc719b869d9cb3f.json
+++ b/.sqlx/query-f3f58600e971f1be6cbe206bba24f77769f54c6230e28f5b3dc719b869d9cb3f.json
@@ -6,42 +6,90 @@
       {
         "ordinal": 0,
         "name": "id",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "id"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "first_name",
-        "type_info": "Varchar"
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "first_name"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "last_name",
-        "type_info": "Varchar"
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "last_name"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "email",
-        "type_info": "Varchar"
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "email"
+          }
+        }
       },
       {
         "ordinal": 4,
         "name": "password_hash",
-        "type_info": "Varchar"
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "password_hash"
+          }
+        }
       },
       {
         "ordinal": 5,
         "name": "role",
-        "type_info": "Varchar"
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "role"
+          }
+        }
       },
       {
         "ordinal": 6,
         "name": "created_at",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "created_at"
+          }
+        }
       },
       {
         "ordinal": 7,
         "name": "updated_at",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "updated_at"
+          }
+        }
       }
     ],
     "parameters": {

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1269,6 +1269,7 @@ dependencies = [
  "once_cell",
  "rand_core 0.6.4",
  "serde",
+ "sha2 0.10.9",
  "tracing",
  "uuid",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,4 @@ utoipa = { version = "^5.4", features = ["uuid", "chrono"] }
 thiserror = "^2.0"
 anyhow = "^1"
 once_cell = "^1.21"
+sha2 = "^0.10"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Smarter Home provides:
 - **Real-time energy monitoring** with TimescaleDB time-series database
 - **Web dashboard** built with Next.js 16 and modern React components
 - **RESTful API** powered by Rust and Axum framework
-- **JWT + session-cookie auth flow** for secure API access
+- **JWT + rotating refresh token flow** for secure API access
 - **Docker containerization** for easy deployment
 
 ## 🏗️ Architecture
@@ -31,7 +31,7 @@ Smarter Home provides:
 - **Frontend**: Next.js 16 + TypeScript + TailwindCSS + Shadcn UI
 - **Database**: TimescaleDB (PostgreSQL with time-series extensions)
 - **Containerization**: Docker + Docker Compose
-- **Authentication**: Backend JWT + httpOnly session cookie
+- **Authentication**: Backend JWT access token + rotating refresh token in httpOnly cookies
 
 ## 🚀 Quick Start
 
@@ -262,6 +262,8 @@ API_URL=http://localhost:3001
 
 # Auth settings
 AUTH_SECRET=your-secret-key
+AUTH_ACCESS_TTL_SECS=900
+AUTH_REFRESH_TTL_SECS=2592000
 ```
 
 For a full variable-by-variable reference, see `docs/environment-variables.md`.

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -1,6 +1,7 @@
 # Authentication Flow
 
-This project uses JWT-based authentication with backend token issuance and webapp cookie-based session storage.
+This project uses short-lived JWT access tokens with rotating refresh tokens.
+The backend issues and validates tokens, and the webapp stores them in httpOnly cookies.
 
 Auth.js and GitHub OAuth are not part of the current authentication flow.
 
@@ -10,8 +11,17 @@ Defined in src/services/api/src/routes/auth.rs:
 
 - POST /auth/login
 - POST /auth/signup
+- POST /auth/refresh
+- POST /auth/logout
 
-Both return an AuthBody that contains an access token.
+Login, signup, and refresh return AuthBody with:
+
+- accessToken
+- refreshToken
+- tokenType
+- expiresIn
+
+Logout revokes the provided refresh token.
 
 ## Webapp auth API routes
 
@@ -19,30 +29,44 @@ Webapp route handlers proxy auth calls and manage browser session cookie:
 
 - app/api/auth/login/route.ts
 - app/api/auth/register/route.ts
+- app/api/auth/refresh/route.ts
 - app/api/auth/logout/route.ts
 - app/api/auth/session/route.ts
 
-On login/register success, the webapp stores __session as an httpOnly cookie.
+On login/register/refresh success, the webapp stores:
+
+- __session (access token)
+- __refresh (refresh token)
 
 ## Session cookie behavior
 
-Cookie name: __session
+Cookie names:
+
+- __session
+- __refresh
 
 Configured with:
 
 - httpOnly: true
 - sameSite: strict
 - secure: true in production
-- expiration aligned with JWT exp claim
+- __session expiration aligned with JWT exp claim
+- __refresh expiration aligned with AUTH_REFRESH_TTL_SECS
 
 ## Backend token validation
 
 Backend request auth extraction uses Claims in src/lib/lib-utils/src/crypto.rs.
 Handlers that require auth rely on Claims extraction from Authorization: Bearer <token>.
 
+Refresh tokens are stored hashed in the database and rotated on each successful refresh.
+
 ## Server-to-backend API calls
 
 src/services/webapp/lib/api.ts reads __session and sends Authorization header for server-side requests.
+
+If backend returns 401 and __refresh is available, apiFetch attempts one refresh and one retry.
+
+src/services/webapp/middleware.ts proactively refreshes tokens on protected app routes when access token is missing or expired.
 
 ## Security expectations
 

--- a/docs/backend-guidelines.md
+++ b/docs/backend-guidelines.md
@@ -30,6 +30,14 @@ Scope: Rust backend and shared Rust libraries.
 - API handlers should include Utoipa annotations.
 - New endpoints must be registered in OpenAPI aggregation.
 - Keep request and response types accurate in docs.
+- Auth endpoint changes must keep docs/auth.md synchronized (login/signup/refresh/logout contracts).
+
+## Auth endpoint behavior
+
+- Access tokens should remain short-lived and signed with AUTH_SECRET.
+- Refresh tokens should be persisted hashed in the database.
+- Refresh flow should rotate refresh tokens on every successful refresh.
+- Logout should revoke active refresh token(s) and not rely on client-side cookie deletion alone.
 
 ## Code quality gates
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -57,6 +57,14 @@ Copy .env.example to .env before local development.
   - Purpose: backend JWT signing/verification secret.
   - Used in: src/lib/lib-utils/src/crypto.rs
   - Required for non-default secure environments.
+- AUTH_ACCESS_TTL_SECS:
+  - Purpose: access token lifetime in seconds.
+  - Default: 900 (15 minutes).
+  - Used in: src/lib/lib-utils/src/crypto.rs.
+- AUTH_REFRESH_TTL_SECS:
+  - Purpose: refresh token lifetime in seconds.
+  - Default: 2592000 (30 days).
+  - Used in: backend refresh token expiration and webapp refresh-cookie expiration.
 
 ## Removed/deprecated variables
 

--- a/migrations/0008_refresh-tokens.down.sql
+++ b/migrations/0008_refresh-tokens.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS refresh_tokens;

--- a/migrations/0008_refresh-tokens.up.sql
+++ b/migrations/0008_refresh-tokens.up.sql
@@ -1,0 +1,21 @@
+CREATE TABLE IF NOT EXISTS refresh_tokens (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    token_hash VARCHAR(128) NOT NULL UNIQUE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    expires_at TIMESTAMPTZ NOT NULL,
+    revoked_at TIMESTAMPTZ,
+    last_used_at TIMESTAMPTZ,
+    replaced_by_id UUID REFERENCES refresh_tokens(id) ON DELETE SET NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_refresh_tokens_user_active
+    ON refresh_tokens(user_id)
+    WHERE revoked_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_refresh_tokens_expires_active
+    ON refresh_tokens(expires_at)
+    WHERE revoked_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_refresh_tokens_token_hash
+    ON refresh_tokens(token_hash);

--- a/src/lib/lib-db/src/lib.rs
+++ b/src/lib/lib-db/src/lib.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 pub mod config;
 pub mod home;
 pub mod power;
+pub mod refresh_token;
 pub mod user;
 
 /// Db struct representing the database connection pool

--- a/src/lib/lib-db/src/refresh_token/mod.rs
+++ b/src/lib/lib-db/src/refresh_token/mod.rs
@@ -1,0 +1,138 @@
+use crate::Db;
+use chrono::{DateTime, Utc};
+use lib_models::error::Error;
+use serde::{Deserialize, Serialize};
+use sqlx::FromRow;
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+pub struct RefreshToken {
+    pub id: Uuid,
+    pub user_id: Uuid,
+    pub token_hash: String,
+    pub created_at: DateTime<Utc>,
+    pub expires_at: DateTime<Utc>,
+    pub revoked_at: Option<DateTime<Utc>>,
+    pub last_used_at: Option<DateTime<Utc>>,
+    pub replaced_by_id: Option<Uuid>,
+}
+
+impl RefreshToken {
+    pub async fn create(
+        db: &Db,
+        user_id: Uuid,
+        token_hash: &str,
+        expires_at: DateTime<Utc>,
+    ) -> Result<Self, Error> {
+        let token = sqlx::query_as::<_, RefreshToken>(
+            r#"
+            INSERT INTO refresh_tokens (user_id, token_hash, expires_at)
+            VALUES ($1, $2, $3)
+            RETURNING id, user_id, token_hash, created_at, expires_at, revoked_at, last_used_at, replaced_by_id
+            "#,
+        )
+        .bind(user_id)
+        .bind(token_hash)
+        .bind(expires_at)
+        .fetch_one(&db.pool)
+        .await?;
+
+        Ok(token)
+    }
+
+    pub async fn get_active_by_hash(db: &Db, token_hash: &str) -> Result<Self, Error> {
+        let token = sqlx::query_as::<_, RefreshToken>(
+            r#"
+            SELECT id, user_id, token_hash, created_at, expires_at, revoked_at, last_used_at, replaced_by_id
+            FROM refresh_tokens
+            WHERE token_hash = $1
+              AND revoked_at IS NULL
+              AND expires_at > NOW()
+            "#,
+        )
+        .bind(token_hash)
+        .fetch_optional(&db.pool)
+        .await?;
+
+        match token {
+            Some(token) => Ok(token),
+            None => Err(Error::Unauthorized),
+        }
+    }
+
+    pub async fn rotate(
+        db: &Db,
+        current_id: Uuid,
+        new_token_hash: &str,
+        new_expires_at: DateTime<Utc>,
+    ) -> Result<Self, Error> {
+        let mut tx = db.pool.begin().await?;
+
+        let old_token = sqlx::query_as::<_, RefreshToken>(
+            r#"
+            SELECT id, user_id, token_hash, created_at, expires_at, revoked_at, last_used_at, replaced_by_id
+            FROM refresh_tokens
+            WHERE id = $1
+              AND revoked_at IS NULL
+              AND expires_at > NOW()
+            FOR UPDATE
+            "#,
+        )
+        .bind(current_id)
+        .fetch_optional(&mut *tx)
+        .await?;
+
+        let old_token = match old_token {
+            Some(token) => token,
+            None => return Err(Error::Unauthorized),
+        };
+
+        let new_token = sqlx::query_as::<_, RefreshToken>(
+            r#"
+            INSERT INTO refresh_tokens (user_id, token_hash, expires_at)
+            VALUES ($1, $2, $3)
+            RETURNING id, user_id, token_hash, created_at, expires_at, revoked_at, last_used_at, replaced_by_id
+            "#,
+        )
+        .bind(old_token.user_id)
+        .bind(new_token_hash)
+        .bind(new_expires_at)
+        .fetch_one(&mut *tx)
+        .await?;
+
+        sqlx::query(
+            r#"
+            UPDATE refresh_tokens
+            SET revoked_at = NOW(),
+                last_used_at = NOW(),
+                replaced_by_id = $2
+            WHERE id = $1
+            "#,
+        )
+        .bind(old_token.id)
+        .bind(new_token.id)
+        .execute(&mut *tx)
+        .await?;
+
+        tx.commit().await?;
+
+        Ok(new_token)
+    }
+
+    pub async fn revoke_by_hash(db: &Db, token_hash: &str) -> Result<(), Error> {
+        sqlx::query(
+            r#"
+            UPDATE refresh_tokens
+            SET revoked_at = NOW(),
+                last_used_at = NOW()
+            WHERE token_hash = $1
+              AND revoked_at IS NULL
+            "#,
+        )
+        .bind(token_hash)
+        .execute(&db.pool)
+        .await?;
+
+        Ok(())
+    }
+}

--- a/src/lib/lib-models/src/domain/auth.rs
+++ b/src/lib/lib-models/src/domain/auth.rs
@@ -11,24 +11,47 @@ use utoipa::ToSchema;
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct AuthBody {
-    message: String,
-    access_token: String,
-    token_type: String,
+    pub message: String,
+    pub access_token: String,
+    pub refresh_token: String,
+    pub token_type: String,
+    pub expires_in: usize,
 }
 impl AuthBody {
     /// Creates a new AuthBody
     /// # Arguments
     /// * `access_token` - Access token
+    /// * `refresh_token` - Refresh token
+    /// * `expires_in` - Access token expiration time in seconds
     /// * `message` - Message
     /// # Returns
     /// * `AuthBody` - New AuthBody
-    pub fn new(access_token: String, message: String) -> Self {
+    pub fn new(
+        access_token: String,
+        refresh_token: String,
+        expires_in: usize,
+        message: String,
+    ) -> Self {
         Self {
             message,
-            access_token: access_token.clone(),
+            access_token,
+            refresh_token,
             token_type: "Bearer".to_string(),
+            expires_in,
         }
     }
+}
+
+#[derive(Debug, Deserialize, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct RefreshTokenRequest {
+    pub refresh_token: String,
+}
+
+#[derive(Debug, Deserialize, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct LogoutRequest {
+    pub refresh_token: String,
 }
 
 // TODO: Implement this instead of AuthUser for more generic OAuth2-style authentication

--- a/src/lib/lib-utils/Cargo.toml
+++ b/src/lib/lib-utils/Cargo.toml
@@ -17,6 +17,7 @@ axum = { workspace = true }
 axum-extra = { workspace = true }
 tracing = { workspace = true }
 once_cell = { workspace = true }
+sha2 = { workspace = true }
 
 # external crates from crates.io
 argon2 = "^0.5"

--- a/src/lib/lib-utils/src/crypto.rs
+++ b/src/lib/lib-utils/src/crypto.rs
@@ -12,8 +12,12 @@ use jsonwebtoken::{decode, encode, Algorithm, DecodingKey, EncodingKey, Header, 
 use lib_models::{error::Error, HashedPassword, Role};
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use std::time::{SystemTime, UNIX_EPOCH};
 use uuid::Uuid;
+
+const DEFAULT_ACCESS_TTL_SECS: usize = 15 * 60;
+const DEFAULT_REFRESH_TTL_SECS: i64 = 30 * 24 * 60 * 60;
 
 /// Static KEYS instance to hold encoding and decoding keys
 static KEYS: Lazy<Keys> = Lazy::new(|| {
@@ -132,6 +136,33 @@ pub fn generate_base64_token() -> String {
     BASE64_URL_SAFE_NO_PAD.encode(&random_bytes)
 }
 
+fn read_env_usize(name: &str, default: usize) -> usize {
+    std::env::var(name)
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(default)
+}
+
+pub fn access_token_ttl_secs() -> usize {
+    read_env_usize("AUTH_ACCESS_TTL_SECS", DEFAULT_ACCESS_TTL_SECS)
+}
+
+pub fn refresh_token_ttl_secs() -> i64 {
+    read_env_usize("AUTH_REFRESH_TTL_SECS", DEFAULT_REFRESH_TTL_SECS as usize) as i64
+}
+
+pub fn generate_refresh_token() -> String {
+    let mut random_bytes = Uuid::new_v4().as_bytes().to_vec();
+    random_bytes.extend_from_slice(Uuid::new_v4().as_bytes());
+    BASE64_URL_SAFE_NO_PAD.encode(&random_bytes)
+}
+
+pub fn hash_refresh_token(token: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(token.as_bytes());
+    format!("{:x}", hasher.finalize())
+}
+
 /// Function to generate a JWT
 /// # Arguments
 /// * `sub` - The subject (user ID or username) to include in the JWT
@@ -152,7 +183,7 @@ pub fn generate_jwt(sub: String, role: Role, id: Option<Uuid>, indefenant: bool)
                 .duration_since(UNIX_EPOCH)
                 .unwrap()
                 .as_secs() as usize
-                + 3600 * 12 // 1 hour expiration
+                + access_token_ttl_secs()
         }
     };
     // let encoding_key = EncodingKey::from_secret(KEYS.as_bytes());

--- a/src/services/api/src/routes/auth.rs
+++ b/src/services/api/src/routes/auth.rs
@@ -1,12 +1,45 @@
 use axum::extract::State;
 use axum::response::IntoResponse;
 use axum::Json;
-use lib_models::domain::auth::AuthBody;
-use lib_models::domain::user::{AuthUser, NewDomainUser};
+use chrono::{Duration, Utc};
+use lib_models::domain::auth::{AuthBody, LogoutRequest, RefreshTokenRequest};
+use lib_models::domain::user::{AuthUser, DomainUser, NewDomainUser};
 use lib_models::{error::Error, Role};
 use lib_utils::crypto;
+use serde_json::json;
 
 use super::AppState;
+
+async fn issue_auth_body(
+    state: &AppState,
+    user: &DomainUser,
+    message: String,
+) -> Result<AuthBody, Error> {
+    let access_token = crypto::generate_jwt(
+        user.email.clone(),
+        Role::from_text(user.role.as_str()),
+        Some(user.id),
+        false,
+    );
+    let refresh_token = crypto::generate_refresh_token();
+    let refresh_token_hash = crypto::hash_refresh_token(&refresh_token);
+    let refresh_expires_at = Utc::now() + Duration::seconds(crypto::refresh_token_ttl_secs());
+
+    lib_db::refresh_token::RefreshToken::create(
+        &state.db,
+        user.id,
+        &refresh_token_hash,
+        refresh_expires_at,
+    )
+    .await?;
+
+    Ok(AuthBody::new(
+        access_token,
+        refresh_token,
+        crypto::access_token_ttl_secs(),
+        message,
+    ))
+}
 
 /// Authenticates a user and returns a JWT token upon successful login.
 #[utoipa::path(
@@ -29,16 +62,16 @@ pub async fn log_in(
             tracing::debug!("Error authenticating user: {:?}", e);
             Err(e.into_response())
         }
-        Ok(valid_user) => {
-            let token = crypto::generate_jwt(
-                valid_user.email,
-                Role::from_text(valid_user.role.as_str()),
-                Some(valid_user.id),
-                false,
-            );
-            let response = AuthBody::new(token, "User signed in successfully".to_string());
-            Ok(Json(response).into_response())
-        }
+        Ok(valid_user) => match issue_auth_body(
+            &state,
+            &valid_user,
+            "User signed in successfully".to_string(),
+        )
+        .await
+        {
+            Ok(response) => Ok(Json(response).into_response()),
+            Err(e) => Err(e.into_response()),
+        },
     }
 }
 
@@ -74,13 +107,94 @@ pub async fn sign_up(
         Err(e) => Err(e.into_response()),
         Ok(user) => {
             tracing::debug!("User created successfully: {:?}", user.email);
-
-            let token = crypto::generate_jwt(user.email.clone(), Role::User, Some(user.id), false);
-            Ok(Json(AuthBody::new(
-                token,
-                "User signed up successfully".to_string(),
-            ))
-            .into_response())
+            match issue_auth_body(&state, &user, "User signed up successfully".to_string()).await {
+                Ok(response) => Ok(Json(response).into_response()),
+                Err(e) => Err(e.into_response()),
+            }
         }
+    }
+}
+
+/// Rotates an active refresh token and returns a new token pair.
+#[utoipa::path(
+    post,
+    path = "/auth/refresh",
+    tag = "auth",
+    request_body = RefreshTokenRequest,
+    responses(
+        (status = 200, description = "Token refreshed successfully", body = AuthBody),
+        (status = 401, description = "Unauthorized", body = String),
+        (status = 500, description = "Internal Server Error", body = String),
+    )
+)]
+pub async fn refresh_token(
+    State(state): State<AppState>,
+    Json(request): Json<RefreshTokenRequest>,
+) -> impl IntoResponse {
+    let token_hash = crypto::hash_refresh_token(&request.refresh_token);
+
+    let current =
+        match lib_db::refresh_token::RefreshToken::get_active_by_hash(&state.db, &token_hash).await
+        {
+            Ok(token) => token,
+            Err(e) => return Err(e.into_response()),
+        };
+
+    let user = match lib_db::user::User::get(&state.db, current.user_id).await {
+        Ok(user) => user,
+        Err(e) => return Err(e.into_response()),
+    };
+
+    let new_refresh_token = crypto::generate_refresh_token();
+    let new_refresh_hash = crypto::hash_refresh_token(&new_refresh_token);
+    let refresh_expires_at = Utc::now() + Duration::seconds(crypto::refresh_token_ttl_secs());
+
+    if let Err(e) = lib_db::refresh_token::RefreshToken::rotate(
+        &state.db,
+        current.id,
+        &new_refresh_hash,
+        refresh_expires_at,
+    )
+    .await
+    {
+        return Err(e.into_response());
+    }
+
+    let access_token = crypto::generate_jwt(
+        user.email,
+        Role::from_text(user.role.as_str()),
+        Some(user.id),
+        false,
+    );
+
+    Ok(Json(AuthBody::new(
+        access_token,
+        new_refresh_token,
+        crypto::access_token_ttl_secs(),
+        "Token refreshed successfully".to_string(),
+    ))
+    .into_response())
+}
+
+/// Revokes a refresh token.
+#[utoipa::path(
+    post,
+    path = "/auth/logout",
+    tag = "auth",
+    request_body = LogoutRequest,
+    responses(
+        (status = 200, description = "Logged out successfully", body = String),
+        (status = 500, description = "Internal Server Error", body = String),
+    )
+)]
+pub async fn log_out(
+    State(state): State<AppState>,
+    Json(request): Json<LogoutRequest>,
+) -> impl IntoResponse {
+    let token_hash = crypto::hash_refresh_token(&request.refresh_token);
+
+    match lib_db::refresh_token::RefreshToken::revoke_by_hash(&state.db, &token_hash).await {
+        Ok(_) => Ok(Json(json!({ "message": "Logged out successfully" })).into_response()),
+        Err(e) => Err(e.into_response()),
     }
 }

--- a/src/services/api/src/routes/mod.rs
+++ b/src/services/api/src/routes/mod.rs
@@ -25,6 +25,8 @@ pub mod user;
         // Auth
         auth::log_in,
         auth::sign_up,
+        auth::refresh_token,
+        auth::log_out,
         // User
         user::get_me,
         // Home
@@ -55,6 +57,8 @@ pub fn create_router(db: lib_db::Db) -> axum::Router {
     let auth_routes: axum::Router = axum::Router::new()
         .route("/auth/login", post(auth::log_in))
         .route("/auth/signup", post(auth::sign_up))
+        .route("/auth/refresh", post(auth::refresh_token))
+        .route("/auth/logout", post(auth::log_out))
         .with_state(app_state.clone());
 
     let user_routes: axum::Router = axum::Router::new()

--- a/src/services/webapp/AGENTS.md
+++ b/src/services/webapp/AGENTS.md
@@ -5,8 +5,8 @@ This directory follows repository-wide rules from `AGENTS.md` at repo root.
 ## Local rules
 
 - Validate frontend changes with:
-	- `bun run lint`
-	- `bunx tsc --noEmit`
+    - `bun run lint`
+    - `bunx tsc --noEmit`
 - Keep backend communication in server functions and `src/services/webapp/lib/api.ts`.
 - Prefer shared and reusable components for destructive UI interactions.
 

--- a/src/services/webapp/app/api/auth/login/route.ts
+++ b/src/services/webapp/app/api/auth/login/route.ts
@@ -1,9 +1,6 @@
 import { type NextRequest, NextResponse } from 'next/server'
 import { API_URL } from '@/lib/config'
-import {
-    decodeTokenPayload,
-    setAuthCookies,
-} from '@/lib/auth-cookies'
+import { decodeTokenPayload, setAuthCookies } from '@/lib/auth-cookies'
 
 interface UpstreamAuthBody {
     accessToken: string

--- a/src/services/webapp/app/api/auth/login/route.ts
+++ b/src/services/webapp/app/api/auth/login/route.ts
@@ -1,15 +1,13 @@
 import { type NextRequest, NextResponse } from 'next/server'
 import { API_URL } from '@/lib/config'
+import {
+    decodeTokenPayload,
+    setAuthCookies,
+} from '@/lib/auth-cookies'
 
-function decodeTokenPayload(
-    token: string,
-): { sub: string; role: string; id: string | null; exp: number } | null {
-    try {
-        const base64 = token.split('.')[1].replace(/-/g, '+').replace(/_/g, '/')
-        return JSON.parse(atob(base64))
-    } catch {
-        return null
-    }
+interface UpstreamAuthBody {
+    accessToken: string
+    refreshToken: string
 }
 
 export async function POST(request: NextRequest) {
@@ -34,10 +32,10 @@ export async function POST(request: NextRequest) {
         return new NextResponse(error, { status: upstream.status })
     }
 
-    const data = (await upstream.json()) as { accessToken: string }
+    const data = (await upstream.json()) as UpstreamAuthBody
     const payload = decodeTokenPayload(data.accessToken)
 
-    if (!payload) {
+    if (!payload || !data.refreshToken) {
         return NextResponse.json(
             { message: 'Invalid token received from upstream' },
             { status: 500 },
@@ -48,13 +46,12 @@ export async function POST(request: NextRequest) {
         user: { email: payload.sub, role: payload.role, id: payload.id },
     })
 
-    response.cookies.set('__session', data.accessToken, {
-        httpOnly: true,
-        secure: process.env.NODE_ENV === 'production',
-        sameSite: 'strict',
-        expires: new Date(payload.exp * 1000),
-        path: '/',
-    })
+    if (!setAuthCookies(response, data.accessToken, data.refreshToken)) {
+        return NextResponse.json(
+            { message: 'Invalid token received from upstream' },
+            { status: 500 },
+        )
+    }
 
     return response
 }

--- a/src/services/webapp/app/api/auth/logout/route.ts
+++ b/src/services/webapp/app/api/auth/logout/route.ts
@@ -1,10 +1,7 @@
 import { cookies } from 'next/headers'
 import { NextResponse } from 'next/server'
 import { API_URL } from '@/lib/config'
-import {
-    REFRESH_COOKIE_NAME,
-    clearAuthCookies,
-} from '@/lib/auth-cookies'
+import { REFRESH_COOKIE_NAME, clearAuthCookies } from '@/lib/auth-cookies'
 
 export async function POST() {
     const cookieStore = await cookies()

--- a/src/services/webapp/app/api/auth/logout/route.ts
+++ b/src/services/webapp/app/api/auth/logout/route.ts
@@ -1,7 +1,25 @@
+import { cookies } from 'next/headers'
 import { NextResponse } from 'next/server'
+import { API_URL } from '@/lib/config'
+import {
+    REFRESH_COOKIE_NAME,
+    clearAuthCookies,
+} from '@/lib/auth-cookies'
 
 export async function POST() {
+    const cookieStore = await cookies()
+    const refreshToken = cookieStore.get(REFRESH_COOKIE_NAME)?.value
+
+    if (refreshToken) {
+        await fetch(`${API_URL}/auth/logout`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ refreshToken }),
+            cache: 'no-store',
+        }).catch(() => undefined)
+    }
+
     const response = NextResponse.json({ success: true })
-    response.cookies.delete('__session')
+    clearAuthCookies(response)
     return response
 }

--- a/src/services/webapp/app/api/auth/refresh/route.ts
+++ b/src/services/webapp/app/api/auth/refresh/route.ts
@@ -2,11 +2,9 @@ import { cookies } from 'next/headers'
 import { NextResponse } from 'next/server'
 import { API_URL } from '@/lib/config'
 import {
-    ACCESS_COOKIE_NAME,
     REFRESH_COOKIE_NAME,
     clearAuthCookies,
     decodeTokenPayload,
-    isAccessTokenExpired,
     setAuthCookies,
 } from '@/lib/auth-cookies'
 
@@ -15,22 +13,15 @@ interface UpstreamAuthBody {
     refreshToken: string
 }
 
-export async function GET() {
+export async function POST() {
     const cookieStore = await cookies()
-    const accessToken = cookieStore.get(ACCESS_COOKIE_NAME)?.value
     const refreshToken = cookieStore.get(REFRESH_COOKIE_NAME)?.value
 
-    if (accessToken && !isAccessTokenExpired(accessToken)) {
-        const payload = decodeTokenPayload(accessToken)
-        if (payload) {
-            return NextResponse.json({
-                user: { email: payload.sub, role: payload.role, id: payload.id },
-            })
-        }
-    }
-
     if (!refreshToken) {
-        const response = NextResponse.json({ user: null })
+        const response = NextResponse.json(
+            { message: 'Missing refresh token' },
+            { status: 401 },
+        )
         clearAuthCookies(response)
         return response
     }
@@ -43,7 +34,10 @@ export async function GET() {
     })
 
     if (!upstream.ok) {
-        const response = NextResponse.json({ user: null })
+        const response = NextResponse.json(
+            { message: 'Unable to refresh token' },
+            { status: upstream.status },
+        )
         clearAuthCookies(response)
         return response
     }
@@ -52,7 +46,10 @@ export async function GET() {
     const payload = decodeTokenPayload(data.accessToken)
 
     if (!payload || !data.refreshToken) {
-        const response = NextResponse.json({ user: null })
+        const response = NextResponse.json(
+            { message: 'Invalid token received from upstream' },
+            { status: 500 },
+        )
         clearAuthCookies(response)
         return response
     }
@@ -62,7 +59,10 @@ export async function GET() {
     })
 
     if (!setAuthCookies(response, data.accessToken, data.refreshToken)) {
-        const invalidResponse = NextResponse.json({ user: null })
+        const invalidResponse = NextResponse.json(
+            { message: 'Invalid token received from upstream' },
+            { status: 500 },
+        )
         clearAuthCookies(invalidResponse)
         return invalidResponse
     }

--- a/src/services/webapp/app/api/auth/register/route.ts
+++ b/src/services/webapp/app/api/auth/register/route.ts
@@ -1,9 +1,6 @@
 import { type NextRequest, NextResponse } from 'next/server'
 import { API_URL } from '@/lib/config'
-import {
-    decodeTokenPayload,
-    setAuthCookies,
-} from '@/lib/auth-cookies'
+import { decodeTokenPayload, setAuthCookies } from '@/lib/auth-cookies'
 
 interface UpstreamAuthBody {
     accessToken: string

--- a/src/services/webapp/app/api/auth/register/route.ts
+++ b/src/services/webapp/app/api/auth/register/route.ts
@@ -1,15 +1,13 @@
 import { type NextRequest, NextResponse } from 'next/server'
 import { API_URL } from '@/lib/config'
+import {
+    decodeTokenPayload,
+    setAuthCookies,
+} from '@/lib/auth-cookies'
 
-function decodeTokenPayload(
-    token: string,
-): { sub: string; role: string; id: string | null; exp: number } | null {
-    try {
-        const base64 = token.split('.')[1].replace(/-/g, '+').replace(/_/g, '/')
-        return JSON.parse(atob(base64))
-    } catch {
-        return null
-    }
+interface UpstreamAuthBody {
+    accessToken: string
+    refreshToken: string
 }
 
 export async function POST(request: NextRequest) {
@@ -34,10 +32,10 @@ export async function POST(request: NextRequest) {
         return new NextResponse(error, { status: upstream.status })
     }
 
-    const data = (await upstream.json()) as { accessToken: string }
+    const data = (await upstream.json()) as UpstreamAuthBody
     const payload = decodeTokenPayload(data.accessToken)
 
-    if (!payload) {
+    if (!payload || !data.refreshToken) {
         return NextResponse.json(
             { message: 'Invalid token received from upstream' },
             { status: 500 },
@@ -48,13 +46,12 @@ export async function POST(request: NextRequest) {
         user: { email: payload.sub, role: payload.role, id: payload.id },
     })
 
-    response.cookies.set('__session', data.accessToken, {
-        httpOnly: true,
-        secure: process.env.NODE_ENV === 'production',
-        sameSite: 'strict',
-        expires: new Date(payload.exp * 1000),
-        path: '/',
-    })
+    if (!setAuthCookies(response, data.accessToken, data.refreshToken)) {
+        return NextResponse.json(
+            { message: 'Invalid token received from upstream' },
+            { status: 500 },
+        )
+    }
 
     return response
 }

--- a/src/services/webapp/app/api/auth/session/route.ts
+++ b/src/services/webapp/app/api/auth/session/route.ts
@@ -24,7 +24,11 @@ export async function GET() {
         const payload = decodeTokenPayload(accessToken)
         if (payload) {
             return NextResponse.json({
-                user: { email: payload.sub, role: payload.role, id: payload.id },
+                user: {
+                    email: payload.sub,
+                    role: payload.role,
+                    id: payload.id,
+                },
             })
         }
     }

--- a/src/services/webapp/components/ui/skeleton.tsx
+++ b/src/services/webapp/components/ui/skeleton.tsx
@@ -1,13 +1,13 @@
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils'
 
-function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
-  return (
-    <div
-      data-slot="skeleton"
-      className={cn("animate-pulse rounded-md bg-muted", className)}
-      {...props}
-    />
-  )
+function Skeleton({ className, ...props }: React.ComponentProps<'div'>) {
+    return (
+        <div
+            data-slot="skeleton"
+            className={cn('animate-pulse rounded-md bg-muted', className)}
+            {...props}
+        />
+    )
 }
 
 export { Skeleton }

--- a/src/services/webapp/lib/api.ts
+++ b/src/services/webapp/lib/api.ts
@@ -56,7 +56,9 @@ async function fetchWithToken(
     })
 }
 
-async function refreshTokenPair(refreshToken: string): Promise<UpstreamAuthBody | null> {
+async function refreshTokenPair(
+    refreshToken: string,
+): Promise<UpstreamAuthBody | null> {
     const refreshRes = await fetch(`${API_URL}/auth/refresh`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -99,7 +101,9 @@ function setCookiesIfPossible(
     }
 }
 
-function clearCookiesIfPossible(cookieStore: Awaited<ReturnType<typeof cookies>>) {
+function clearCookiesIfPossible(
+    cookieStore: Awaited<ReturnType<typeof cookies>>,
+) {
     try {
         cookieStore.delete(ACCESS_COOKIE_NAME)
         cookieStore.delete(REFRESH_COOKIE_NAME)
@@ -159,7 +163,11 @@ export async function apiFetch<T>(
         return handleResponse<T>(initialRes)
     }
 
-    setCookiesIfPossible(cookieStore, refreshed.accessToken, refreshed.refreshToken)
+    setCookiesIfPossible(
+        cookieStore,
+        refreshed.accessToken,
+        refreshed.refreshToken,
+    )
 
     const retryRes = await fetchWithToken(
         path,

--- a/src/services/webapp/lib/api.ts
+++ b/src/services/webapp/lib/api.ts
@@ -2,8 +2,111 @@ import 'server-only'
 import { cookies } from 'next/headers'
 import { API_URL } from './config'
 import type { ApiError } from '@/types/error'
+import {
+    ACCESS_COOKIE_NAME,
+    REFRESH_COOKIE_NAME,
+    decodeTokenPayload,
+} from '@/lib/auth-cookies'
 
 export type { ApiError }
+
+interface UpstreamAuthBody {
+    accessToken: string
+    refreshToken: string
+}
+
+const DEFAULT_REFRESH_TTL_SECS = 30 * 24 * 60 * 60
+
+function refreshTtlSecs(): number {
+    const rawValue = Number(process.env.AUTH_REFRESH_TTL_SECS)
+    if (!Number.isFinite(rawValue) || rawValue <= 0) {
+        return DEFAULT_REFRESH_TTL_SECS
+    }
+
+    return Math.floor(rawValue)
+}
+
+async function fetchWithToken(
+    path: string,
+    fetchOptions: RequestInit,
+    token: string | undefined,
+    tags?: string[],
+    revalidate?: number,
+): Promise<Response> {
+    const hasBody =
+        fetchOptions.method !== undefined &&
+        fetchOptions.method !== 'GET' &&
+        fetchOptions.body !== undefined
+
+    return fetch(`${API_URL}${path}`, {
+        ...fetchOptions,
+        headers: {
+            ...(hasBody && { 'Content-Type': 'application/json' }),
+            ...(token && { Authorization: `Bearer ${token}` }),
+            ...(fetchOptions.headers as Record<string, string>),
+        },
+        ...(tags || revalidate !== undefined
+            ? {
+                  next: {
+                      ...(tags && { tags }),
+                      ...(revalidate !== undefined && { revalidate }),
+                  },
+              }
+            : {}),
+    })
+}
+
+async function refreshTokenPair(refreshToken: string): Promise<UpstreamAuthBody | null> {
+    const refreshRes = await fetch(`${API_URL}/auth/refresh`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ refreshToken }),
+        cache: 'no-store',
+    })
+
+    if (!refreshRes.ok) return null
+
+    const body = (await refreshRes.json()) as UpstreamAuthBody
+    if (!body.accessToken || !body.refreshToken) return null
+    return body
+}
+
+function setCookiesIfPossible(
+    cookieStore: Awaited<ReturnType<typeof cookies>>,
+    accessToken: string,
+    refreshToken: string,
+) {
+    const payload = decodeTokenPayload(accessToken)
+    if (!payload) return
+
+    try {
+        cookieStore.set(ACCESS_COOKIE_NAME, accessToken, {
+            httpOnly: true,
+            secure: process.env.NODE_ENV === 'production',
+            sameSite: 'strict',
+            expires: new Date(payload.exp * 1000),
+            path: '/',
+        })
+        cookieStore.set(REFRESH_COOKIE_NAME, refreshToken, {
+            httpOnly: true,
+            secure: process.env.NODE_ENV === 'production',
+            sameSite: 'strict',
+            expires: new Date(Date.now() + refreshTtlSecs() * 1000),
+            path: '/',
+        })
+    } catch {
+        // Cookie mutation is not available in all server contexts.
+    }
+}
+
+function clearCookiesIfPossible(cookieStore: Awaited<ReturnType<typeof cookies>>) {
+    try {
+        cookieStore.delete(ACCESS_COOKIE_NAME)
+        cookieStore.delete(REFRESH_COOKIE_NAME)
+    } catch {
+        // Cookie mutation is not available in all server contexts.
+    }
+}
 
 export async function handleResponse<T>(res: Response): Promise<T> {
     if (!res.ok) {
@@ -32,31 +135,43 @@ export async function apiFetch<T>(
     options: RequestInit & { tags?: string[]; revalidate?: number } = {},
 ): Promise<T> {
     const cookieStore = await cookies()
-    const token = cookieStore.get('__session')?.value
+    const accessToken = cookieStore.get(ACCESS_COOKIE_NAME)?.value
+    const refreshToken = cookieStore.get(REFRESH_COOKIE_NAME)?.value
 
     const { tags, revalidate, ...fetchOptions } = options
 
-    const hasBody =
-        fetchOptions.method !== undefined &&
-        fetchOptions.method !== 'GET' &&
-        fetchOptions.body !== undefined
+    const initialRes = await fetchWithToken(
+        path,
+        fetchOptions,
+        accessToken,
+        tags,
+        revalidate,
+    )
 
-    const res = await fetch(`${API_URL}${path}`, {
-        ...fetchOptions,
-        headers: {
-            ...(hasBody && { 'Content-Type': 'application/json' }),
-            ...(token && { Authorization: `Bearer ${token}` }),
-            ...(fetchOptions.headers as Record<string, string>),
-        },
-        ...(tags || revalidate !== undefined
-            ? {
-                  next: {
-                      ...(tags && { tags }),
-                      ...(revalidate !== undefined && { revalidate }),
-                  },
-              }
-            : {}),
-    })
+    if (initialRes.status !== 401 || !refreshToken) {
+        return handleResponse<T>(initialRes)
+    }
 
-    return handleResponse<T>(res)
+    const refreshed = await refreshTokenPair(refreshToken)
+
+    if (!refreshed) {
+        clearCookiesIfPossible(cookieStore)
+        return handleResponse<T>(initialRes)
+    }
+
+    setCookiesIfPossible(cookieStore, refreshed.accessToken, refreshed.refreshToken)
+
+    const retryRes = await fetchWithToken(
+        path,
+        fetchOptions,
+        refreshed.accessToken,
+        tags,
+        revalidate,
+    )
+
+    if (retryRes.status === 401) {
+        clearCookiesIfPossible(cookieStore)
+    }
+
+    return handleResponse<T>(retryRes)
 }

--- a/src/services/webapp/lib/auth-cookies.ts
+++ b/src/services/webapp/lib/auth-cookies.ts
@@ -1,0 +1,77 @@
+import { NextResponse } from 'next/server'
+
+export const ACCESS_COOKIE_NAME = '__session'
+export const REFRESH_COOKIE_NAME = '__refresh'
+
+export interface JwtPayload {
+    sub: string
+    role: string
+    id: string | null
+    exp: number
+}
+
+const DEFAULT_REFRESH_TTL_SECS = 30 * 24 * 60 * 60
+
+function refreshTtlSecs(): number {
+    const rawValue = Number(process.env.AUTH_REFRESH_TTL_SECS)
+    if (!Number.isFinite(rawValue) || rawValue <= 0) {
+        return DEFAULT_REFRESH_TTL_SECS
+    }
+
+    return Math.floor(rawValue)
+}
+
+export function decodeTokenPayload(token: string): JwtPayload | null {
+    try {
+        const base64 = token.split('.')[1]
+        if (!base64) return null
+
+        const normalized = base64.replace(/-/g, '+').replace(/_/g, '/')
+        return JSON.parse(atob(normalized)) as JwtPayload
+    } catch {
+        return null
+    }
+}
+
+export function isAccessTokenExpired(token: string): boolean {
+    const payload = decodeTokenPayload(token)
+    if (!payload) return true
+    return payload.exp * 1000 < Date.now()
+}
+
+function cookieOptions(expires?: Date) {
+    return {
+        httpOnly: true,
+        secure: process.env.NODE_ENV === 'production',
+        sameSite: 'strict' as const,
+        path: '/',
+        ...(expires ? { expires } : {}),
+    }
+}
+
+export function setAuthCookies(
+    response: NextResponse,
+    accessToken: string,
+    refreshToken: string,
+): boolean {
+    const payload = decodeTokenPayload(accessToken)
+    if (!payload) return false
+
+    response.cookies.set(
+        ACCESS_COOKIE_NAME,
+        accessToken,
+        cookieOptions(new Date(payload.exp * 1000)),
+    )
+    response.cookies.set(
+        REFRESH_COOKIE_NAME,
+        refreshToken,
+        cookieOptions(new Date(Date.now() + refreshTtlSecs() * 1000)),
+    )
+
+    return true
+}
+
+export function clearAuthCookies(response: NextResponse) {
+    response.cookies.delete(ACCESS_COOKIE_NAME)
+    response.cookies.delete(REFRESH_COOKIE_NAME)
+}

--- a/src/services/webapp/middleware.ts
+++ b/src/services/webapp/middleware.ts
@@ -1,0 +1,63 @@
+import { NextRequest, NextResponse } from 'next/server'
+import {
+    ACCESS_COOKIE_NAME,
+    REFRESH_COOKIE_NAME,
+    clearAuthCookies,
+    isAccessTokenExpired,
+    setAuthCookies,
+} from '@/lib/auth-cookies'
+
+interface UpstreamAuthBody {
+    accessToken: string
+    refreshToken: string
+}
+
+const API_URL = process.env.API_URL ?? 'http://localhost:3001'
+
+export async function middleware(request: NextRequest) {
+    const accessToken = request.cookies.get(ACCESS_COOKIE_NAME)?.value
+    const refreshToken = request.cookies.get(REFRESH_COOKIE_NAME)?.value
+
+    if (accessToken && !isAccessTokenExpired(accessToken)) {
+        return NextResponse.next()
+    }
+
+    if (!refreshToken) {
+        const response = NextResponse.next()
+        clearAuthCookies(response)
+        return response
+    }
+
+    const upstream = await fetch(`${API_URL}/auth/refresh`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ refreshToken }),
+        cache: 'no-store',
+    }).catch(() => null)
+
+    if (!upstream || !upstream.ok) {
+        const response = NextResponse.next()
+        clearAuthCookies(response)
+        return response
+    }
+
+    const body = (await upstream.json()) as UpstreamAuthBody
+    if (!body.accessToken || !body.refreshToken) {
+        const response = NextResponse.next()
+        clearAuthCookies(response)
+        return response
+    }
+
+    const response = NextResponse.next()
+
+    if (!setAuthCookies(response, body.accessToken, body.refreshToken)) {
+        clearAuthCookies(response)
+        return response
+    }
+
+    return response
+}
+
+export const config = {
+    matcher: ['/dashboard/:path*', '/homes/:path*', '/about/:path*'],
+}


### PR DESCRIPTION
## Description

This pr focuses on improving the auth flow by introducing refresh token with validation middleware. 
Used to be an issue that auth token times out and user will have to sign in again.

## Type of change
- [x] New feature

## Checklist
- [x] I have tested this locally (or explained why I couldn't)
  - [x] without docker
  - [x] with docker
- [x] I have run following code validation comands:
  - [x] Rust lint - `cargo clippy`,
  - [x] Rust formatter - `cargo fmt`
  - [x] Ts/Js lint - `bun run lint`
  - [x] Ts/Js formatter - `bun run format`
- [x] This does not introduce new security risks (shell, file access, email, etc.)
- [x] I considered Windows + Docker + Linux + Mac users
- [x] I updated docs if behavior changed

## Related issues

- #72

## Notes for reviewer

Watch our for any potential security issues.

## Generated summary
This pull request introduces improvements and clarifications to the authentication flow and enhances the metadata in SQLx query files for better traceability. The main changes are updated documentation and environment variables to reflect the use of short-lived JWT access tokens with rotating refresh tokens, and the addition of column origin metadata to SQLx query outputs.

**Authentication flow improvements and documentation:**

* Updated the authentication documentation in `README.md` and `docs/auth.md` to clarify that the system now uses short-lived JWT access tokens with rotating refresh tokens, replacing the previous session-cookie approach. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L11-R11) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L34-R34) [[3]](diffhunk://#diff-d9cbd97d17d60b9a415f168c988e7af55ab4d6945e24b0fb570a0577eff6b884L3-R4)
* Added `AUTH_ACCESS_TTL_SECS` and `AUTH_REFRESH_TTL_SECS` environment variables to `.env.example` and documented their usage in `README.md`. [[1]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cR27-R28) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R265-R266)

**SQLx query metadata enhancements:**

* Updated all SQLx query JSON files to include an `origin` field for each column, specifying the source table and column name. This improves traceability and maintainability for database queries. [[1]](diffhunk://#diff-cc161a523244053f5d78887d3de45ae210ccb477e8a545f54f0c2b1e1cd062f1L9-R59) [[2]](diffhunk://#diff-7c394cd7f3f8b773d3dc8d7e8d06d04e9954bf84d52a6c5b33af81534094de51L9-R70) [[3]](diffhunk://#diff-9cd3f8b58176f42163cacf2fdebe592bfcbabc5aa373d966cc61575d0a52b7c5L9-R147) [[4]](diffhunk://#diff-321b1f140812ac76508751de8b3187946222d8c3888d5a2fd744c50277ba4dfeL9-R92) [[5]](diffhunk://#diff-5ca1ca065d23ab32e2174acf8c4e25e3661e454505f67bac3d2f98a2a5f7b404L9-R26) [[6]](diffhunk://#diff-18198f285082f59f01e93d0f1d09751e52a636098088b105cf809c7d47af2f52L9-R15) [[7]](diffhunk://#diff-039d0b9b3499f0da5e37ec177327992b95eb574e9df4b6f9d3db84146eca4839L9-R15) [[8]](diffhunk://#diff-c6ba6a5f5d96b66161b27ad781d9a3968aa65e355a90df41ff5757af36a1748fL9-R59) [[9]](diffhunk://#diff-282e5dc409887556ca48f4ff8aead48dfe11d1d45dae263da5cf678d7e90b314L9-R92) [[10]](diffhunk://#diff-9aa2a5c9a156c702acf8f2ab02f628c225c2b7aa1f67fc589e271a000c2ed6bbL9-R59) [[11]](diffhunk://#diff-ebc174d2618882739eba8e479c26fc80a37dd95adb96645223c6fbec751ef854L9-R15) [[12]](diffhunk://#diff-99b07ebc94b837333073b4ffa843578763e325d4a65dfade81e738886dc46b7bL9-R15) [[13]](diffhunk://#diff-9be4b194a5cb503588bffe16ac1c64c66e6c5c22de9b4289363811f60bd250a2L9-R92)

**Dependency updates:**

* Added the `sha2` crate to `Cargo.toml`, likely to support cryptographic operations related to authentication tokens.
